### PR TITLE
add shiori types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "uka_macro",
+    "uka_shiori",
     "uka_sstp",
     "uka_util",
 ]

--- a/uka_shiori/Cargo.toml
+++ b/uka_shiori/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "uka_shiori"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+thiserror = "1.0.40"
+uka_util = { path = "../uka_util" }
+
+[dev-dependencies]
+anyhow = "1.0.71"
+rstest = "0.18.1"

--- a/uka_shiori/src/lib.rs
+++ b/uka_shiori/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod types;

--- a/uka_shiori/src/types.rs
+++ b/uka_shiori/src/types.rs
@@ -1,0 +1,7 @@
+mod request;
+mod response;
+
+pub mod v3;
+
+pub use request::{Request, RequestExt, RequestParseError};
+pub use response::{Response, ResponseExt, ResponseParseError};

--- a/uka_shiori/src/types/request.rs
+++ b/uka_shiori/src/types/request.rs
@@ -1,0 +1,101 @@
+use crate::types::v3;
+
+#[derive(thiserror::Error, Debug)]
+pub enum RequestParseError {
+    #[error("failed parse: invalid request")]
+    InvalidRequest,
+
+    #[error("{0}")]
+    V3(#[from] v3::ParseError),
+}
+
+/// `Request` is a type that represents a SHIORI request.
+///
+/// This type supports multiple versions of SHIORI.
+/// If you want to support only a specific version, use `uka_shiori::types::v3::Request` and a specific version explicitly.
+pub enum Request {
+    V3(v3::Request),
+}
+
+impl Request {
+    /// Parse a bytes into a Request.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use uka_shiori::types::Request;
+    /// # use uka_shiori::types::v3::Version;
+    /// #
+    /// let input = [
+    ///     b"GET SHIORI/3.0\r\n".to_vec(),
+    ///     b"Sender: Materia\r\n".to_vec(),
+    ///     b"ID: hoge\r\n".to_vec(),
+    ///     b"Reference0: uge\r\n".to_vec(),
+    ///     b"Charset: UTF-8\r\n".to_vec(),
+    ///     b"\r\n".to_vec()
+    /// ].concat();
+    ///
+    /// match Request::parse(&input) {
+    ///     Ok(Request::V3(request)) => {
+    ///        assert_eq!(request.version(), Version::SHIORI_30);
+    ///     },
+    ///     Err(e) => panic!("{e}"),
+    /// }
+    /// ```
+    pub fn parse(buf: &[u8]) -> Result<Self, RequestParseError> {
+        #[allow(clippy::if_same_then_else)]
+        if b"GET SHIORI/3.0" == &buf[..14] || b"NOTIFY SHIORI/3.0" == &buf[..17] {
+            // parse as SHIORI/3.0
+            Ok(Request::V3(
+                v3::Request::parse(buf).map_err(RequestParseError::from)?,
+            ))
+        } else if b"GET" == &buf[..3] || b"NOTIFY" == &buf[..6] || b"TEACH" == &buf[..5] {
+            // parse as SHIORI/2.x
+            Err(RequestParseError::InvalidRequest)
+        } else {
+            // parse as SHIORI/1.x
+            Err(RequestParseError::InvalidRequest)
+        }
+    }
+
+    /// Convert request to bytes.
+    pub fn as_bytes(&self) -> Vec<u8> {
+        match self {
+            Self::V3(request) => request.as_bytes(),
+        }
+    }
+}
+
+impl From<v3::Request> for Request {
+    fn from(value: v3::Request) -> Self {
+        Self::V3(value)
+    }
+}
+
+/// `RequestExt` is a trait that extends the `Request` type.
+pub trait RequestExt<V, R> {
+    /// Returns a concrete request builder by specifying a version.
+    fn builder(version: V) -> R;
+}
+
+impl RequestExt<v3::Version, v3::RequestBuilder> for Request {
+    /// Returns a concrete request builder by specifying a version.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use uka_shiori::types::{Request, RequestExt, v3};
+    /// #
+    /// let request = Request::builder(v3::Version::SHIORI_30)
+    ///   .method(v3::Method::GET)
+    ///   .header(v3::HeaderName::SENDER, "Materia")
+    ///   .header(v3::HeaderName::ID, "version")
+    ///   .charset(v3::Charset::UTF8)
+    ///   .build()
+    ///   .unwrap();
+    /// assert_eq!(request.version(), v3::Version::SHIORI_30);
+    /// ```
+    fn builder(version: v3::Version) -> v3::RequestBuilder {
+        v3::RequestBuilder::new().version(version)
+    }
+}

--- a/uka_shiori/src/types/response.rs
+++ b/uka_shiori/src/types/response.rs
@@ -1,0 +1,99 @@
+use crate::types::v3;
+
+#[derive(thiserror::Error, Debug)]
+pub enum ResponseParseError {
+    #[error("failed parse: invalid request")]
+    InvalidRequest,
+
+    #[error("{0}")]
+    V3(#[from] v3::ParseError),
+}
+
+/// `Response` is a type that represents a SHIORI request.
+///
+/// This type supports multiple versions of SHIORI.
+/// If you want to support only a specific version, use `uka_shiori::types::v3::Response` and a specific version explicitly.
+pub enum Response {
+    V3(v3::Response),
+}
+
+impl Response {
+    /// Parse a bytes into a Request.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use uka_shiori::types::Response;
+    /// # use uka_shiori::types::v3::Version;
+    /// #
+    /// let input = [
+    ///     b"SHIORI/3.0 204 No Content\r\n".to_vec(),
+    ///     b"Sender: F.I.R.S.T\r\n".to_vec(),
+    ///     b"Value: hoge\r\n".to_vec(),
+    ///     b"Charset: UTF-8\r\n".to_vec(),
+    ///     b"\r\n".to_vec(),
+    /// ].concat();
+    ///
+    /// match Response::parse(&input) {
+    ///     Ok(Response::V3(response)) => {
+    ///       assert_eq!(response.version(), Version::SHIORI_30);
+    ///     },
+    ///     Err(e) => panic!("{e}"),
+    /// }
+    /// ```
+    pub fn parse(buf: &[u8]) -> Result<Self, ResponseParseError> {
+        #[allow(clippy::if_same_then_else)]
+        if b"SHIORI/3" == buf[..8].as_ref() {
+            // parse as SHIORI/3.0
+            Ok(Response::V3(v3::Response::parse(buf)?))
+        } else if b"SHIORI/2" == buf[..8].as_ref() {
+            // parse as SHIORI/2.x
+            Err(ResponseParseError::InvalidRequest)
+        } else {
+            // parse as SHIORI/1.x
+            Err(ResponseParseError::InvalidRequest)
+        }
+    }
+
+    /// Convert response to bytes.
+    pub fn as_bytes(&self) -> Vec<u8> {
+        match self {
+            Self::V3(request) => request.as_bytes(),
+        }
+    }
+}
+
+impl From<v3::Response> for Response {
+    fn from(value: v3::Response) -> Self {
+        Self::V3(value)
+    }
+}
+
+/// `ResponseExt` is a trait that extends the `Response` type.
+pub trait ResponseExt<V, R> {
+    /// Returns a concrete response builder by specifying a version.
+    fn builder(version: V) -> R;
+}
+
+impl ResponseExt<v3::Version, v3::ResponseBuilder> for Response {
+    /// Returns a concrete response builder by specifying a version.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use uka_shiori::types::{Response, ResponseExt};
+    /// # use uka_shiori::types::v3::{Charset, HeaderName, StatusCode, Version};
+    /// #
+    /// let response = Response::builder(Version::SHIORI_30)
+    ///   .status_code(StatusCode::NO_CONTENT)
+    ///   .header(HeaderName::SENDER, "F.I.R.S.T")
+    ///   .header(HeaderName::VALUE, "hoge")
+    ///   .charset(Charset::UTF8)
+    ///   .build()
+    ///   .unwrap();
+    /// assert_eq!(response.version(), Version::SHIORI_30);
+    /// ```
+    fn builder(version: v3::Version) -> v3::ResponseBuilder {
+        v3::ResponseBuilder::new().version(version)
+    }
+}

--- a/uka_shiori/src/types/response.rs
+++ b/uka_shiori/src/types/response.rs
@@ -2,8 +2,8 @@ use crate::types::v3;
 
 #[derive(thiserror::Error, Debug)]
 pub enum ResponseParseError {
-    #[error("failed parse: invalid request")]
-    InvalidRequest,
+    #[error("failed parse: invalid response")]
+    InvalidResponse,
 
     #[error("{0}")]
     V3(#[from] v3::ParseError),
@@ -48,10 +48,10 @@ impl Response {
             Ok(Response::V3(v3::Response::parse(buf)?))
         } else if b"SHIORI/2" == buf[..8].as_ref() {
             // parse as SHIORI/2.x
-            Err(ResponseParseError::InvalidRequest)
+            Err(ResponseParseError::InvalidResponse)
         } else {
             // parse as SHIORI/1.x
-            Err(ResponseParseError::InvalidRequest)
+            Err(ResponseParseError::InvalidResponse)
         }
     }
 

--- a/uka_shiori/src/types/v3.rs
+++ b/uka_shiori/src/types/v3.rs
@@ -11,7 +11,7 @@ pub use charset::{Charset, Error as CharsetError};
 pub use header::{HeaderMap, HeaderName, HeaderNameError, HeaderValue, HeaderValueError};
 pub use method::Method;
 pub use parse::Error as ParseError;
-pub use request::{Builder as RequestBuilder, Error as RequestBuilderError, Request};
+pub use request::{Error as RequestBuilderError, Request, RequestBuilder};
 pub use response::{Builder as ResponseBuilder, Error as ResponseBuilderError, Response};
 pub use status::StatusCode;
 pub use version::Version;

--- a/uka_shiori/src/types/v3.rs
+++ b/uka_shiori/src/types/v3.rs
@@ -1,0 +1,17 @@
+mod charset;
+mod header;
+mod method;
+mod parse;
+mod request;
+mod response;
+mod status;
+mod version;
+
+pub use charset::{Charset, Error as CharsetError};
+pub use header::{HeaderMap, HeaderName, HeaderNameError, HeaderValue, HeaderValueError};
+pub use method::Method;
+pub use parse::Error as ParseError;
+pub use request::{Builder as RequestBuilder, Error as RequestBuilderError, Request};
+pub use response::{Builder as ResponseBuilder, Error as ResponseBuilderError, Response};
+pub use status::StatusCode;
+pub use version::Version;

--- a/uka_shiori/src/types/v3/charset.rs
+++ b/uka_shiori/src/types/v3/charset.rs
@@ -1,0 +1,113 @@
+use std::fmt;
+
+/// Error that can occur when converting Charset from string.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(
+        "invalid charset `{0}`, the charset must be ASCII, Shift_JIS, ISO-2022-JP, EUC-JP or UTF-8"
+    )]
+    Invalid(String),
+}
+type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, PartialEq, PartialOrd, Copy, Clone, Eq, Ord, Hash)]
+enum Inner {
+    Ascii,
+    ShiftJis,
+    Iso2022Jp,
+    EucJp,
+    Utf8,
+}
+
+/// Charset is the character set and encoding of strings in SHIORI headers.
+///
+/// ```rust
+/// # use uka_shiori::types::v3::Charset;
+/// #
+/// # let charset = Charset::ASCII;
+/// match charset {
+///     Charset::ASCII => assert_eq!(charset.to_string(), "ASCII"),
+///     Charset::SHIFT_JIS => assert_eq!(charset.to_string(), "Shift_JIS"),
+///     Charset::ISO2022JP => assert_eq!(charset.to_string(), "ISO-2022-JP"),
+///     Charset::EUC_JP => assert_eq!(charset.to_string(), "EUC-JP"),
+///     Charset::UTF8 => assert_eq!(charset.to_string(), "UTF-8"),
+/// }
+/// ```
+#[derive(Debug, PartialEq, PartialOrd, Copy, Clone, Eq, Ord, Hash)]
+pub struct Charset(Inner);
+impl Charset {
+    /// ASCII
+    pub const ASCII: Charset = Charset(Inner::Ascii);
+
+    /// Shift_JIS
+    pub const SHIFT_JIS: Charset = Charset(Inner::ShiftJis);
+
+    /// ISO-2022-JP
+    pub const ISO2022JP: Charset = Charset(Inner::Iso2022Jp);
+
+    /// EUC-JP
+    pub const EUC_JP: Charset = Charset(Inner::EucJp);
+
+    /// UTF-8
+    pub const UTF8: Charset = Charset(Inner::Utf8);
+
+    ///　Converts a str to Charset.
+    ///
+    /// ```rust
+    /// # use uka_shiori::types::v3::Charset;
+    ///
+    /// assert_eq!(Charset::ASCII, Charset::from_static("ASCII").unwrap());
+    /// assert_eq!(Charset::SHIFT_JIS, Charset::from_static("Shift_JIS").unwrap());
+    /// assert_eq!(Charset::ISO2022JP, Charset::from_static("ISO-2022-JP").unwrap());
+    /// assert_eq!(Charset::EUC_JP, Charset::from_static("EUC-JP").unwrap());
+    /// assert_eq!(Charset::UTF8, Charset::from_static("UTF-8").unwrap());
+    /// ```
+    pub fn from_static(s: &str) -> Result<Charset> {
+        match s {
+            "ASCII" => Ok(Charset::ASCII),
+            "Shift_JIS" => Ok(Charset::SHIFT_JIS),
+            "ISO-2022-JP" => Ok(Charset::ISO2022JP),
+            "EUC-JP" => Ok(Charset::EUC_JP),
+            "UTF-8" => Ok(Charset::UTF8),
+            _ => Err(Error::Invalid(s.to_string())),
+        }
+    }
+
+    ///　Converts a string to Charset.
+    pub fn from_string(s: impl Into<String>) -> Result<Charset> {
+        Charset::from_static(s.into().as_str())
+    }
+}
+
+impl fmt::Display for Charset {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use self::Inner::*;
+
+        f.write_str(match self.0 {
+            Ascii => "ASCII",
+            ShiftJis => "Shift_JIS",
+            Iso2022Jp => "ISO-2022-JP",
+            EucJp => "EUC-JP",
+            Utf8 => "UTF-8",
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_static_invalid_charset() {
+        let result = Charset::from_static("Unsupported Charset");
+        assert!(result.is_err());
+        matches!(result.unwrap_err(), Error::Invalid(_));
+    }
+
+    #[test]
+    fn test_from_string_invalid_charset() {
+        let result = Charset::from_string("Unsupported Charset");
+        assert!(result.is_err());
+        matches!(result.unwrap_err(), Error::Invalid(_));
+    }
+}

--- a/uka_shiori/src/types/v3/header.rs
+++ b/uka_shiori/src/types/v3/header.rs
@@ -1,0 +1,8 @@
+pub use name::{Error as HeaderNameError, HeaderName};
+use uka_util::bag::OrderedBag;
+pub use value::{Error as HeaderValueError, HeaderValue};
+
+mod name;
+mod value;
+
+pub type HeaderMap = OrderedBag<HeaderName, HeaderValue>;

--- a/uka_shiori/src/types/v3/header/name.rs
+++ b/uka_shiori/src/types/v3/header/name.rs
@@ -1,0 +1,291 @@
+use std::fmt::Display;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum Inner {
+    Charset,
+    Sender,
+    ID,
+    Reference0,
+    Reference1,
+    Reference2,
+    Reference3,
+    Reference4,
+    Reference5,
+    Reference6,
+    Reference7,
+    SecurityLevel,
+    Value,
+    Other(String),
+}
+
+/// Error that can occur when convert from string.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("invalid header name: {0}")]
+    InvalidHeaderName(String),
+}
+
+/// HeaderName is the name of the SHIORI header field.
+///
+/// It has some field names defined based on SHIORI specifications and extended proprietary field names.
+/// HeaderName is used as a key in the HeaderMap; constants are available for header names based on the SHIORI specification.
+#[derive(Debug, Hash, PartialEq, Eq, Clone)]
+pub struct HeaderName(Inner);
+
+impl HeaderName {
+    /// Charset
+    pub const CHARSET: HeaderName = HeaderName(Inner::Charset);
+
+    /// Sender
+    pub const SENDER: HeaderName = HeaderName(Inner::Sender);
+
+    /// ID
+    pub const ID: HeaderName = HeaderName(Inner::ID);
+
+    /// Reference0
+    pub const REFERENCE0: HeaderName = HeaderName(Inner::Reference0);
+
+    /// Reference1
+    pub const REFERENCE1: HeaderName = HeaderName(Inner::Reference1);
+
+    /// Reference2
+    pub const REFERENCE2: HeaderName = HeaderName(Inner::Reference2);
+
+    /// Reference3
+    pub const REFERENCE3: HeaderName = HeaderName(Inner::Reference3);
+
+    /// Reference4
+    pub const REFERENCE4: HeaderName = HeaderName(Inner::Reference4);
+
+    /// Reference5
+    pub const REFERENCE5: HeaderName = HeaderName(Inner::Reference5);
+
+    /// Reference6
+    pub const REFERENCE6: HeaderName = HeaderName(Inner::Reference6);
+
+    /// Reference7
+    pub const REFERENCE7: HeaderName = HeaderName(Inner::Reference7);
+
+    /// SecurityLevel
+    pub const SECURITY_LEVEL: HeaderName = HeaderName(Inner::SecurityLevel);
+
+    /// Value
+    pub const VALUE: HeaderName = HeaderName(Inner::Value);
+
+    ///　Converts a str to HeaderName.
+    ///
+    /// ```rust
+    /// # use uka_shiori::types::v3::HeaderName;
+    /// assert_eq!(HeaderName::from_static("Charset").unwrap(), HeaderName::CHARSET);
+    /// assert_eq!(HeaderName::from_static("Sender").unwrap(), HeaderName::SENDER);
+    /// assert_eq!(HeaderName::from_static("ID").unwrap(), HeaderName::ID);
+    /// assert_eq!(HeaderName::from_static("Reference0").unwrap(), HeaderName::REFERENCE0);
+    /// assert_eq!(HeaderName::from_static("Reference1").unwrap(), HeaderName::REFERENCE1);
+    /// assert_eq!(HeaderName::from_static("Reference2").unwrap(), HeaderName::REFERENCE2);
+    /// assert_eq!(HeaderName::from_static("Reference3").unwrap(), HeaderName::REFERENCE3);
+    /// assert_eq!(HeaderName::from_static("Reference4").unwrap(), HeaderName::REFERENCE4);
+    /// assert_eq!(HeaderName::from_static("Reference5").unwrap(), HeaderName::REFERENCE5);
+    /// assert_eq!(HeaderName::from_static("Reference6").unwrap(), HeaderName::REFERENCE6);
+    /// assert_eq!(HeaderName::from_static("Reference7").unwrap(), HeaderName::REFERENCE7);
+    /// assert_eq!(HeaderName::from_static("SecurityLevel").unwrap(), HeaderName::SECURITY_LEVEL);
+    /// assert_eq!(HeaderName::from_static("Value").unwrap(), HeaderName::VALUE);
+    /// ```
+    pub fn from_static(s: &str) -> Result<HeaderName, Error> {
+        match s {
+            "Charset" => Ok(HeaderName(Inner::Charset)),
+            "Sender" => Ok(HeaderName(Inner::Sender)),
+            "ID" => Ok(HeaderName(Inner::ID)),
+            "Reference0" => Ok(HeaderName(Inner::Reference0)),
+            "Reference1" => Ok(HeaderName(Inner::Reference1)),
+            "Reference2" => Ok(HeaderName(Inner::Reference2)),
+            "Reference3" => Ok(HeaderName(Inner::Reference3)),
+            "Reference4" => Ok(HeaderName(Inner::Reference4)),
+            "Reference5" => Ok(HeaderName(Inner::Reference5)),
+            "Reference6" => Ok(HeaderName(Inner::Reference6)),
+            "Reference7" => Ok(HeaderName(Inner::Reference7)),
+            "SecurityLevel" => Ok(HeaderName(Inner::SecurityLevel)),
+            "Value" => Ok(HeaderName(Inner::Value)),
+            _ => {
+                let valid = s.as_bytes().iter().all(|byte| matches!(*byte, b'0'..=b'9' | b'!' | b'#'..=b'\'' | b'*'..=b'+' | b'-'..=b'.' | b'^'..=b'`' | b'A'..=b'Z' | b'a'..=b'z' | b'|' | b'~'));
+                if valid {
+                    Ok(HeaderName(Inner::Other(s.to_string())))
+                } else {
+                    Err(Error::InvalidHeaderName(s.to_string()))
+                }
+            }
+        }
+    }
+
+    ///　Converts a bytes to HeaderName.
+    ///
+    /// ```rust
+    /// # use uka_shiori::types::v3::HeaderName;
+    /// assert_eq!(HeaderName::from_bytes(b"Charset").unwrap(), HeaderName::CHARSET);
+    /// assert_eq!(HeaderName::from_bytes(b"Sender").unwrap(), HeaderName::SENDER);
+    /// assert_eq!(HeaderName::from_bytes(b"ID").unwrap(), HeaderName::ID);
+    /// assert_eq!(HeaderName::from_bytes(b"Reference0").unwrap(), HeaderName::REFERENCE0);
+    /// assert_eq!(HeaderName::from_bytes(b"Reference1").unwrap(), HeaderName::REFERENCE1);
+    /// assert_eq!(HeaderName::from_bytes(b"Reference2").unwrap(), HeaderName::REFERENCE2);
+    /// assert_eq!(HeaderName::from_bytes(b"Reference3").unwrap(), HeaderName::REFERENCE3);
+    /// assert_eq!(HeaderName::from_bytes(b"Reference4").unwrap(), HeaderName::REFERENCE4);
+    /// assert_eq!(HeaderName::from_bytes(b"Reference5").unwrap(), HeaderName::REFERENCE5);
+    /// assert_eq!(HeaderName::from_bytes(b"Reference6").unwrap(), HeaderName::REFERENCE6);
+    /// assert_eq!(HeaderName::from_bytes(b"Reference7").unwrap(), HeaderName::REFERENCE7);
+    /// assert_eq!(HeaderName::from_bytes(b"SecurityLevel").unwrap(), HeaderName::SECURITY_LEVEL);
+    /// assert_eq!(HeaderName::from_bytes(b"Value").unwrap(), HeaderName::VALUE);
+    /// ```
+    pub fn from_bytes(bytes: &[u8]) -> Result<HeaderName, Error> {
+        let s = String::from_utf8_lossy(bytes);
+        HeaderName::from_static(s.as_ref())
+    }
+
+    ///　Converts a HeaderName to bytes.
+    ///
+    /// ```rust
+    /// # use uka_shiori::types::v3::HeaderName;
+    /// assert_eq!(HeaderName::CHARSET.as_bytes(), b"Charset");
+    /// assert_eq!(HeaderName::SENDER.as_bytes(), b"Sender");
+    /// assert_eq!(HeaderName::ID.as_bytes(), b"ID");
+    /// assert_eq!(HeaderName::REFERENCE0.as_bytes(), b"Reference0");
+    /// assert_eq!(HeaderName::REFERENCE1.as_bytes(), b"Reference1");
+    /// assert_eq!(HeaderName::REFERENCE2.as_bytes(), b"Reference2");
+    /// assert_eq!(HeaderName::REFERENCE3.as_bytes(), b"Reference3");
+    /// assert_eq!(HeaderName::REFERENCE4.as_bytes(), b"Reference4");
+    /// assert_eq!(HeaderName::REFERENCE5.as_bytes(), b"Reference5");
+    /// assert_eq!(HeaderName::REFERENCE6.as_bytes(), b"Reference6");
+    /// assert_eq!(HeaderName::REFERENCE7.as_bytes(), b"Reference7");
+    /// assert_eq!(HeaderName::SECURITY_LEVEL.as_bytes(), b"SecurityLevel");
+    /// assert_eq!(HeaderName::VALUE.as_bytes(), b"Value");
+    /// assert_eq!(HeaderName::from_static("X-Extend-Header").unwrap().as_bytes(), b"X-Extend-Header");
+    /// ```
+    pub fn as_bytes(&self) -> Vec<u8> {
+        self.to_string().into_bytes()
+    }
+}
+
+impl Display for HeaderName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.0 {
+            Inner::Charset => write!(f, "Charset"),
+            Inner::Sender => write!(f, "Sender"),
+            Inner::ID => write!(f, "ID"),
+            Inner::Reference0 => write!(f, "Reference0"),
+            Inner::Reference1 => write!(f, "Reference1"),
+            Inner::Reference2 => write!(f, "Reference2"),
+            Inner::Reference3 => write!(f, "Reference3"),
+            Inner::Reference4 => write!(f, "Reference4"),
+            Inner::Reference5 => write!(f, "Reference5"),
+            Inner::Reference6 => write!(f, "Reference6"),
+            Inner::Reference7 => write!(f, "Reference7"),
+            Inner::SecurityLevel => write!(f, "SecurityLevel"),
+            Inner::Value => write!(f, "Value"),
+            Inner::Other(s) => write!(f, "{s}"),
+        }
+    }
+}
+
+impl From<HeaderName> for String {
+    fn from(header_name: HeaderName) -> Self {
+        header_name.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+    use rstest::rstest;
+
+    #[test]
+    fn test_from_static_pass_alpha() -> Result<()> {
+        let name = HeaderName::from_static("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")?;
+        assert_eq!(
+            name.to_string(),
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_static_pass_digit() -> Result<()> {
+        let name = HeaderName::from_static("1234567890")?;
+        assert_eq!(name.to_string(), "1234567890");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_static_pass_acceptable_symbol() -> Result<()> {
+        let name = HeaderName::from_static("!#$%&'*+-.^_`|~")?;
+        assert_eq!(name.to_string(), "!#$%&'*+-.^_`|~");
+
+        Ok(())
+    }
+
+    #[rstest]
+    #[case::nul("\0")]
+    #[case::soh("\x01")]
+    #[case::stx("\x02")]
+    #[case::etx("\x03")]
+    #[case::eot("\x04")]
+    #[case::enq("\x05")]
+    #[case::ack("\x06")]
+    #[case::bel("\x07")]
+    #[case::bs("\x08")]
+    #[case::ht("\x09")]
+    #[case::lf("\n")]
+    #[case::vt("\x0b")]
+    #[case::ff("\x0c")]
+    #[case::cr("\r")]
+    #[case::so("\x0e")]
+    #[case::si("\x0f")]
+    #[case::dle("\x10")]
+    #[case::dc1("\x11")]
+    #[case::dc2("\x12")]
+    #[case::dc3("\x13")]
+    #[case::dc4("\x14")]
+    #[case::nak("\x15")]
+    #[case::syn("\x16")]
+    #[case::etb("\x17")]
+    #[case::can("\x18")]
+    #[case::em("\x19")]
+    #[case::sub("\x1a")]
+    #[case::esc("\x1b")]
+    #[case::fs("\x1c")]
+    #[case::gs("\x1d")]
+    #[case::rs("\x1e")]
+    #[case::us("\x1f")]
+    #[case::delete("\x7f")]
+    fn test_from_static_failed_control_character(#[case] input: String) -> Result<()> {
+        let res = HeaderName::from_static(&input);
+        assert!(res.is_err());
+        matches!(res, Err(Error::InvalidHeaderName(s)) if s == input);
+
+        Ok(())
+    }
+
+    #[rstest]
+    #[case::left_parenthesis("(")]
+    #[case::right_parenthesis(")")]
+    #[case::comma(",")]
+    #[case::slash("/")]
+    #[case::semicolon(";")]
+    #[case::less_than_sign("<")]
+    #[case::equals_sign("=")]
+    #[case::greater_than_sign(">")]
+    #[case::question_mark("?")]
+    #[case::at_sign("@")]
+    #[case::left_square_bracket("[")]
+    #[case::backslash("\\")]
+    #[case::right_square_bracket("]")]
+    #[case::left_curly_brace("{")]
+    #[case::right_curly_brace("}")]
+    fn test_from_static_failed_unavailable_symbols(#[case] input: String) -> Result<()> {
+        let res = HeaderName::from_static(&input);
+        assert!(res.is_err());
+        matches!(res, Err(Error::InvalidHeaderName(s)) if s == input);
+
+        Ok(())
+    }
+}

--- a/uka_shiori/src/types/v3/header/value.rs
+++ b/uka_shiori/src/types/v3/header/value.rs
@@ -1,0 +1,287 @@
+use crate::types::v3::charset::Charset;
+use uka_util::decode::{Decoder, Error as DecodeError};
+use uka_util::encode::{Encoder, Error as EncodeError};
+
+/// Error occurs when serializing/deserializing HeaderValue.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("HeaderValue cannot handle strings that contain unprintable characters: {0}")]
+    UnprintableCharacters(String),
+
+    #[error("{0}")]
+    FailedEncode(#[from] EncodeError),
+
+    #[error("{0}")]
+    FailedDecode(#[from] DecodeError),
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+/// HeaderValue is the value of the SHIORI header field.
+///
+/// The value is held in a byte string of the character set and encoding that can be specified in Charset.
+/// Since it is not possible to determine which SHIORI header fields are allowed to contain multibyte characters
+/// and which actually contain multibyte characters,
+/// users should specify them explicitly when retrieving them.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct HeaderValue(Vec<u8>);
+impl HeaderValue {
+    /// Extract HeaderValue as an ASCII code string.
+    ///
+    /// ```rust
+    /// # use uka_shiori::types::v3::HeaderValue;
+    /// # use anyhow::Result;
+    /// # fn main() -> Result<()> {
+    /// assert_eq!(HeaderValue::from_static("sakura")?.text()?, "sakura");
+    /// #     Ok(())
+    /// # }
+    /// ```
+    pub fn text(&self) -> Result<String> {
+        self.text_with_charset(Charset::ASCII)
+    }
+
+    /// Extract HeaderValue as a string with Charset
+    /// ```rust
+    /// # use uka_shiori::types::v3::{HeaderValue, Charset};
+    /// # use anyhow::Result;
+    /// # fn main() -> Result<()> {
+    /// let input = [130, 179, 130, 173, 130, 231].to_vec();
+    /// assert_eq!(HeaderValue::from(input).text_with_charset(Charset::SHIFT_JIS)?, "さくら");
+    /// #     Ok(())
+    /// # }
+    /// ```
+    pub fn text_with_charset(&self, charset: Charset) -> Result<String> {
+        let text = match charset {
+            Charset::ASCII => Decoder::decode_ascii(&self.0)?,
+            Charset::SHIFT_JIS => Decoder::decode_sjis(&self.0)?,
+            Charset::ISO2022JP => Decoder::decode_iso_2022_jp(&self.0)?,
+            Charset::EUC_JP => Decoder::decode_euc_jp(&self.0)?,
+            Charset::UTF8 => Decoder::decode_utf8(&self.0)?,
+        };
+
+        if text.chars().any(|c| c.is_ascii_control()) {
+            return Err(Error::UnprintableCharacters(text));
+        }
+
+        Ok(text)
+    }
+
+    ///　Convert string to HeaderValue with ASCII code bytes.
+    ///
+    /// ```rust
+    /// # use uka_shiori::types::v3::HeaderValue;
+    /// assert_eq!(HeaderValue::from_static("sakura").unwrap().as_bytes(), b"sakura");
+    /// ```
+    pub fn from_static(s: &str) -> Result<Self> {
+        Self::from_static_with_charset(s, Charset::ASCII)
+    }
+
+    ///　Convert string to HeaderValue with Charset.
+    ///
+    ///```rust
+    /// # use uka_shiori::types::v3::{Charset, HeaderValue};
+    /// assert_eq!(
+    ///    HeaderValue::from_static_with_charset("さくら", Charset::SHIFT_JIS).unwrap().as_bytes(),
+    ///    [130, 179, 130, 173, 130, 231]);
+    /// ```
+    pub fn from_static_with_charset(s: &str, charset: Charset) -> Result<Self> {
+        if s.chars().any(|c| c.is_ascii_control()) {
+            return Err(Error::UnprintableCharacters(s.to_string()));
+        }
+
+        let bytes = match charset {
+            Charset::ASCII => Encoder::encode_ascii(s)?,
+            Charset::SHIFT_JIS => Encoder::encode_sjis(s)?,
+            Charset::ISO2022JP => Encoder::encode_iso_2022_jp(s)?,
+            Charset::EUC_JP => Encoder::encode_euc_jp(s)?,
+            Charset::UTF8 => Encoder::encode_utf8(s)?,
+        };
+        Ok(Self(bytes))
+    }
+
+    /// Convert HeaderValue to bytes.
+    pub fn as_bytes(&self) -> Vec<u8> {
+        self.0.clone()
+    }
+}
+
+impl From<&[u8]> for HeaderValue {
+    fn from(s: &[u8]) -> Self {
+        Self(s.to_vec())
+    }
+}
+
+impl From<Vec<u8>> for HeaderValue {
+    fn from(s: Vec<u8>) -> Self {
+        Self(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+    use rstest::rstest;
+
+    #[test]
+    pub fn test_from_static_with_charset_pass_ascii() -> Result<()> {
+        let header_value = HeaderValue::from_static_with_charset("sakura", Charset::ASCII)?;
+        assert_eq!(header_value.as_bytes(), b"sakura");
+        Ok(())
+    }
+
+    #[test]
+    pub fn test_from_static_with_charset_pass_sjis() -> Result<()> {
+        let header_value = HeaderValue::from_static_with_charset("さくら", Charset::SHIFT_JIS)?;
+        assert_eq!(header_value.as_bytes(), [130, 179, 130, 173, 130, 231]);
+        Ok(())
+    }
+
+    #[test]
+    pub fn test_from_static_with_charset_pass_iso2022jp() -> Result<()> {
+        let header_value = HeaderValue::from_static_with_charset("さくら", Charset::ISO2022JP)?;
+        assert_eq!(
+            header_value.as_bytes(),
+            [27, 36, 66, 36, 53, 36, 47, 36, 105, 27, 40, 66]
+        );
+        Ok(())
+    }
+
+    #[test]
+    pub fn test_from_static_with_charset_pass_eucjp() -> Result<()> {
+        let header_value = HeaderValue::from_static_with_charset("さくら", Charset::EUC_JP)?;
+        assert_eq!(header_value.as_bytes(), [164, 181, 164, 175, 164, 233]);
+        Ok(())
+    }
+
+    #[test]
+    pub fn test_from_static_with_charset_pass_utf8() -> Result<()> {
+        let header_value = HeaderValue::from_static_with_charset("さくら", Charset::UTF8)?;
+        assert_eq!(
+            header_value.as_bytes(),
+            [227, 129, 149, 227, 129, 143, 227, 130, 137]
+        );
+        Ok(())
+    }
+
+    #[rstest]
+    #[case::nul("\0")]
+    #[case::soh("\x01")]
+    #[case::stx("\x02")]
+    #[case::etx("\x03")]
+    #[case::eot("\x04")]
+    #[case::enq("\x05")]
+    #[case::ack("\x06")]
+    #[case::bel("\x07")]
+    #[case::bs("\x08")]
+    #[case::ht("\x09")]
+    #[case::lf("\n")]
+    #[case::vt("\x0b")]
+    #[case::ff("\x0c")]
+    #[case::cr("\r")]
+    #[case::so("\x0e")]
+    #[case::si("\x0f")]
+    #[case::dle("\x10")]
+    #[case::dc1("\x11")]
+    #[case::dc2("\x12")]
+    #[case::dc3("\x13")]
+    #[case::dc4("\x14")]
+    #[case::nak("\x15")]
+    #[case::syn("\x16")]
+    #[case::etb("\x17")]
+    #[case::can("\x18")]
+    #[case::em("\x19")]
+    #[case::sub("\x1a")]
+    #[case::esc("\x1b")]
+    #[case::fs("\x1c")]
+    #[case::gs("\x1d")]
+    #[case::rs("\x1e")]
+    #[case::us("\x1f")]
+    #[case::delete("\x7f")]
+    fn test_from_static_with_charset_failed_control_character(#[case] input: String) -> Result<()> {
+        let res = HeaderValue::from_static(&input);
+        assert!(res.is_err());
+        matches!(res, Err(Error::UnprintableCharacters(s)) if s == input);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_text_with_charset_pass_ascii() -> Result<()> {
+        let value = HeaderValue::from(b"sakura".to_vec());
+        assert_eq!(value.text_with_charset(Charset::ASCII)?, "sakura");
+        Ok(())
+    }
+
+    #[test]
+    fn test_text_with_charset_pass_sjis() -> Result<()> {
+        let value = HeaderValue::from([130, 179, 130, 173, 130, 231].to_vec());
+        assert_eq!(value.text_with_charset(Charset::SHIFT_JIS)?, "さくら");
+        Ok(())
+    }
+
+    #[test]
+    fn test_text_with_charset_pass_iso2022jp() -> Result<()> {
+        let value = HeaderValue::from([27, 36, 66, 36, 53, 36, 47, 36, 105, 27, 40, 66].to_vec());
+        assert_eq!(value.text_with_charset(Charset::ISO2022JP)?, "さくら");
+        Ok(())
+    }
+
+    #[test]
+    fn test_text_with_charset_pass_eucjp() -> Result<()> {
+        let value = HeaderValue::from([164, 181, 164, 175, 164, 233].to_vec());
+        assert_eq!(value.text_with_charset(Charset::EUC_JP)?, "さくら");
+        Ok(())
+    }
+
+    #[test]
+    fn test_text_with_charset_pass_utf8() -> Result<()> {
+        let value = HeaderValue::from([227, 129, 149, 227, 129, 143, 227, 130, 137].to_vec());
+        assert_eq!(value.text_with_charset(Charset::UTF8)?, "さくら");
+        Ok(())
+    }
+
+    #[rstest]
+    #[case::nul(b"\0")]
+    #[case::soh(b"\x01")]
+    #[case::stx(b"\x02")]
+    #[case::etx(b"\x03")]
+    #[case::eot(b"\x04")]
+    #[case::enq(b"\x05")]
+    #[case::ack(b"\x06")]
+    #[case::bel(b"\x07")]
+    #[case::bs(b"\x08")]
+    #[case::ht(b"\x09")]
+    #[case::lf(b"\n")]
+    #[case::vt(b"\x0b")]
+    #[case::ff(b"\x0c")]
+    #[case::cr(b"\r")]
+    #[case::so(b"\x0e")]
+    #[case::si(b"\x0f")]
+    #[case::dle(b"\x10")]
+    #[case::dc1(b"\x11")]
+    #[case::dc2(b"\x12")]
+    #[case::dc3(b"\x13")]
+    #[case::dc4(b"\x14")]
+    #[case::nak(b"\x15")]
+    #[case::syn(b"\x16")]
+    #[case::etb(b"\x17")]
+    #[case::can(b"\x18")]
+    #[case::em(b"\x19")]
+    #[case::sub(b"\x1a")]
+    #[case::esc(b"\x1b")]
+    #[case::fs(b"\x1c")]
+    #[case::gs(b"\x1d")]
+    #[case::rs(b"\x1e")]
+    #[case::us(b"\x1f")]
+    #[case::delete(b"\x7f")]
+    fn test_text_with_charset_failed_control_character(#[case] input: &[u8]) -> Result<()> {
+        let value = HeaderValue::from(input);
+        let res = value.text();
+
+        assert!(res.is_err());
+        matches!(res, Err(Error::UnprintableCharacters(_)));
+
+        Ok(())
+    }
+}

--- a/uka_shiori/src/types/v3/method.rs
+++ b/uka_shiori/src/types/v3/method.rs
@@ -1,0 +1,38 @@
+use std::fmt;
+
+#[derive(Debug, PartialEq, PartialOrd, Copy, Clone, Eq, Ord, Hash)]
+enum Inner {
+    Get,
+    Notify,
+}
+
+/// Method is the method of the SHIORI request.
+///
+/// ```rust
+/// # use uka_shiori::types::v3::Method;
+/// # let method = Method::GET;
+/// match method {
+///     Method::GET => assert_eq!(method.to_string(), "GET"),
+///     Method::NOTIFY => assert_eq!(method.to_string(), "NOTIFY"),
+/// }
+/// ```
+#[derive(Debug, PartialEq, PartialOrd, Copy, Clone, Eq, Ord, Hash)]
+pub struct Method(Inner);
+impl Method {
+    /// Get
+    pub const GET: Method = Method(Inner::Get);
+
+    /// Notify
+    pub const NOTIFY: Method = Method(Inner::Notify);
+}
+
+impl fmt::Display for Method {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use self::Inner::*;
+
+        f.write_str(match self.0 {
+            Get => "GET",
+            Notify => "NOTIFY",
+        })
+    }
+}

--- a/uka_shiori/src/types/v3/parse.rs
+++ b/uka_shiori/src/types/v3/parse.rs
@@ -1,0 +1,149 @@
+use crate::types::v3::charset::{Charset, Error as CharsetError};
+use crate::types::v3::header::{HeaderMap, HeaderName, HeaderNameError, HeaderValueError};
+use crate::types::v3::method::Method;
+use crate::types::v3::request::Request;
+use crate::types::v3::response::Response;
+use crate::types::v3::status::StatusCode;
+use crate::types::v3::version::Version;
+use std::io::Cursor;
+use uka_util::cursor::{lookahead, read_expect, read_match, read_repeat, read_until};
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("{0}")]
+    IO(#[from] std::io::Error),
+
+    #[error("invalid header name: {0:?}")]
+    InvalidHeaderName(#[from] HeaderNameError),
+
+    #[error("`{0}` header not found")]
+    MissingHeader(HeaderName),
+
+    #[error("{1} in `{0}` header")]
+    FailedDecode(HeaderName, #[source] HeaderValueError),
+
+    #[error("{0}")]
+    UnsupportedCharset(#[from] CharsetError),
+
+    #[error("unexpected eof")]
+    UnexpectedEof,
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+pub fn parse_request(input: &[u8]) -> Result<Request> {
+    let mut cursor = Cursor::new(input);
+    let method = parse_method(&mut cursor)?;
+    skip_spaces(&mut cursor)?;
+    let version = parse_version(&mut cursor)?;
+    skip_newline(&mut cursor)?;
+    let headers = parse_headers(&mut cursor)?;
+    let charset = headers
+        .get(&HeaderName::CHARSET)
+        .ok_or_else(|| Error::MissingHeader(HeaderName::CHARSET))
+        .and_then(|v| {
+            v.text()
+                .map_err(|e| Error::FailedDecode(HeaderName::CHARSET, e))
+        })
+        .and_then(|v| Charset::from_string(v).map_err(Error::from))?;
+    skip_newline(&mut cursor)?;
+    eof(&mut cursor)?;
+
+    Ok(Request {
+        method,
+        version,
+        headers,
+        charset,
+    })
+}
+
+pub fn parse_response(input: &[u8]) -> Result<Response> {
+    let mut cursor = Cursor::new(input);
+    let version = parse_version(&mut cursor)?;
+    skip_spaces(&mut cursor)?;
+    let status_code = parse_status_code(&mut cursor)?;
+    skip_newline(&mut cursor)?;
+    let headers = parse_headers(&mut cursor)?;
+    let charset = headers
+        .get(&HeaderName::CHARSET)
+        .ok_or_else(|| Error::MissingHeader(HeaderName::CHARSET))
+        .and_then(|v| {
+            v.text()
+                .map_err(|e| Error::FailedDecode(HeaderName::CHARSET, e))
+        })
+        .and_then(|v| Charset::from_string(v).map_err(Error::from))?;
+    skip_newline(&mut cursor)?;
+    eof(&mut cursor)?;
+
+    Ok(Response {
+        version,
+        status_code,
+        headers,
+        charset,
+    })
+}
+
+fn parse_method(cursor: &mut Cursor<&[u8]>) -> Result<Method> {
+    read_match!(cursor, {
+        b"GET" => Method::GET,
+        b"NOTIFY" => Method::NOTIFY,
+    })
+    .map_err(Error::from)
+}
+
+fn parse_version(cursor: &mut Cursor<&[u8]>) -> Result<Version> {
+    read_match!(cursor, {
+        b"SHIORI/3.0" => Version::SHIORI_30,
+    })
+    .map_err(Error::from)
+}
+
+fn parse_status_code(cursor: &mut Cursor<&[u8]>) -> Result<StatusCode> {
+    read_match!(cursor, {
+        b"200 OK" => StatusCode::OK,
+        b"204 No Content" => StatusCode::NO_CONTENT,
+        b"310 Communicate" => StatusCode::COMMUNICATE,
+        b"311 Not Enough" => StatusCode::NOT_ENOUGH,
+        b"312 Advice" => StatusCode::ADVICE,
+        b"400 Bad Request" => StatusCode::BAD_REQUEST,
+        b"500 Internal Server Error" => StatusCode::INTERNAL_SERVER_ERROR,
+    }, 3)
+    .map_err(Error::from)
+}
+
+fn parse_headers(cursor: &mut Cursor<&[u8]>) -> Result<HeaderMap> {
+    let mut map = HeaderMap::new();
+    loop {
+        let buffer = lookahead!(cursor, 2).map_err(Error::from)?;
+        if &buffer == b"\r\n" {
+            break;
+        }
+        let name = read_until!(cursor, b":").map_err(Error::from)?;
+        skip_spaces(cursor)?;
+        let value = read_until!(cursor, b"\r\n").map_err(Error::from)?;
+
+        map.insert(
+            HeaderName::from_bytes(&name).map_err(Error::from)?,
+            value.into(),
+        )
+    }
+    Ok(map)
+}
+
+fn skip_spaces(cursor: &mut Cursor<&[u8]>) -> Result<()> {
+    read_repeat!(cursor, b" ").map_err(Error::from)?;
+    Ok(())
+}
+
+fn skip_newline(cursor: &mut Cursor<&[u8]>) -> Result<()> {
+    read_expect!(cursor, b"\r\n").map_err(Error::from)?;
+    Ok(())
+}
+
+fn eof(cursor: &mut Cursor<&[u8]>) -> Result<()> {
+    if cursor.position() as usize == cursor.get_ref().len() {
+        Ok(())
+    } else {
+        Err(Error::UnexpectedEof)
+    }
+}

--- a/uka_shiori/src/types/v3/parse.rs
+++ b/uka_shiori/src/types/v3/parse.rs
@@ -5,6 +5,7 @@ use crate::types::v3::request::Request;
 use crate::types::v3::response::Response;
 use crate::types::v3::status::StatusCode;
 use crate::types::v3::version::Version;
+use crate::types::v3::ParseError;
 use std::io::Cursor;
 use uka_util::cursor::{lookahead, read_expect, read_match, read_repeat, read_until};
 
@@ -45,7 +46,8 @@ pub fn parse_request(input: &[u8]) -> Result<Request> {
             v.text()
                 .map_err(|e| Error::FailedDecode(HeaderName::CHARSET, e))
         })
-        .and_then(|v| Charset::from_string(v).map_err(Error::from))?;
+        .and_then(|v| Charset::from_string(v).map_err(Error::from))
+        .or_else(|_| Ok::<Charset, ParseError>(Charset::ASCII))?;
     skip_newline(&mut cursor)?;
     eof(&mut cursor)?;
 
@@ -71,7 +73,8 @@ pub fn parse_response(input: &[u8]) -> Result<Response> {
             v.text()
                 .map_err(|e| Error::FailedDecode(HeaderName::CHARSET, e))
         })
-        .and_then(|v| Charset::from_string(v).map_err(Error::from))?;
+        .and_then(|v| Charset::from_string(v).map_err(Error::from))
+        .or_else(|_| Ok::<Charset, ParseError>(Charset::ASCII))?;
     skip_newline(&mut cursor)?;
     eof(&mut cursor)?;
 

--- a/uka_shiori/src/types/v3/request.rs
+++ b/uka_shiori/src/types/v3/request.rs
@@ -1,0 +1,350 @@
+use crate::types::v3::charset::Charset;
+use crate::types::v3::header::{
+    HeaderMap, HeaderName, HeaderNameError, HeaderValue, HeaderValueError,
+};
+use crate::types::v3::parse::{parse_request, Error as ParseError};
+use crate::types::v3::{Method, Version};
+use std::collections::HashMap;
+
+/// Request is a type that represents an SHIORI v3 request.
+///
+/// Request provides a builder to generate types, a parser to generate types from bytes,
+/// and an accessor to the headers defined in the specification.
+///
+/// # Examples
+///
+/// ```rust
+/// # use uka_shiori::types::v3::{Charset, HeaderName, Method, Version, Request};
+/// let request = Request::builder()
+///     .method(Method::GET)
+///     .version(Version::SHIORI_30)
+///     .header(HeaderName::SENDER, "Materia")
+///     .header(HeaderName::ID, "hoge")
+///     .header(HeaderName::REFERENCE0, "uge")
+///     .charset(Charset::ASCII)
+///     .build()
+///     .unwrap();
+/// assert_eq!(request.method(), Method::GET);
+/// ```
+pub struct Request {
+    pub(crate) method: Method,
+    pub(crate) version: Version,
+    pub(crate) headers: HeaderMap,
+    pub(crate) charset: Charset,
+}
+
+impl Request {
+    /// Parse a bytes into a Request.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use uka_shiori::types::v3::{Request, Method};
+    /// #
+    /// let input = [
+    ///     b"GET SHIORI/3.0\r\n".to_vec(),
+    ///     b"Sender: Materia\r\n".to_vec(),
+    ///     b"ID: hoge\r\n".to_vec(),
+    ///     b"Reference0: uge\r\n".to_vec(),
+    ///     b"Charset: UTF-8\r\n".to_vec(),
+    ///     b"\r\n".to_vec()
+    /// ].concat();
+    /// let request = Request::parse(&input).unwrap();
+    /// assert_eq!(request.method(), Method::GET);
+    /// ```
+    pub fn parse(buf: &[u8]) -> Result<Self, ParseError> {
+        parse_request(buf)
+    }
+
+    /// Returns a builder that generates a type for the Request
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use uka_shiori::types::v3::{Request, Method, Version, HeaderName, Charset};
+    /// #
+    /// let request = Request::builder()
+    ///    .method(Method::GET)
+    ///    .version(Version::SHIORI_30)
+    ///    .header(HeaderName::SENDER, "Materia")
+    ///    .header(HeaderName::ID, "hoge")
+    ///    .header(HeaderName::REFERENCE0, "uge")
+    ///    .charset(Charset::ASCII)
+    ///    .build()
+    ///    .unwrap();
+    /// assert_eq!(request.method(), Method::GET);
+    /// ```
+    pub fn builder() -> Builder {
+        Builder::new()
+    }
+
+    /// Returns SHIORI method.
+    pub fn method(&self) -> Method {
+        self.method
+    }
+
+    /// Returns SHIORI version.
+    pub fn version(&self) -> Version {
+        self.version
+    }
+
+    /// Returns SHIORI header fields.
+    pub fn headers(&self) -> &HeaderMap {
+        &self.headers
+    }
+
+    /// Returns SHIORI charset.
+    pub fn charset(&self) -> Charset {
+        self.charset
+    }
+
+    /// Returns sender in SHIORI header fields.
+    pub fn sender(&self) -> Option<&HeaderValue> {
+        self.headers.get(&HeaderName::SENDER)
+    }
+
+    /// Returns ID in SHIORI header fields.
+    pub fn id(&self) -> Option<&HeaderValue> {
+        self.headers.get(&HeaderName::ID)
+    }
+
+    /// Returns Reference0 in SHIORI header fields.
+    pub fn reference0(&self) -> Option<&HeaderValue> {
+        self.headers.get(&HeaderName::REFERENCE0)
+    }
+
+    /// Returns Reference1 in SHIORI header fields.
+    pub fn reference1(&self) -> Option<&HeaderValue> {
+        self.headers.get(&HeaderName::REFERENCE1)
+    }
+
+    /// Returns Reference2 in SHIORI header fields.
+    pub fn reference2(&self) -> Option<&HeaderValue> {
+        self.headers.get(&HeaderName::REFERENCE2)
+    }
+
+    /// Returns Reference3 in SHIORI header fields.
+    pub fn reference3(&self) -> Option<&HeaderValue> {
+        self.headers.get(&HeaderName::REFERENCE3)
+    }
+
+    /// Returns Reference4 in SHIORI header fields.
+    pub fn reference4(&self) -> Option<&HeaderValue> {
+        self.headers.get(&HeaderName::REFERENCE4)
+    }
+
+    /// Returns Reference5 in SHIORI header fields.
+    pub fn reference5(&self) -> Option<&HeaderValue> {
+        self.headers.get(&HeaderName::REFERENCE5)
+    }
+
+    /// Returns Reference6 in SHIORI header fields.
+    pub fn reference6(&self) -> Option<&HeaderValue> {
+        self.headers.get(&HeaderName::REFERENCE6)
+    }
+
+    /// Returns Reference7 in SHIORI header fields.
+    pub fn reference7(&self) -> Option<&HeaderValue> {
+        self.headers.get(&HeaderName::REFERENCE7)
+    }
+
+    /// Returns SecurityLevel in SHIORI header fields.
+    pub fn security_level(&self) -> Option<&HeaderValue> {
+        self.headers.get(&HeaderName::SECURITY_LEVEL)
+    }
+
+    /// Convert request to bytes.
+    pub fn as_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(self.method.to_string().as_bytes());
+        buf.extend_from_slice(b" ");
+        buf.extend_from_slice(self.version.to_string().as_bytes());
+        buf.extend_from_slice(b"\r\n");
+        for (name, value) in self.headers.iter() {
+            buf.extend_from_slice(&name.as_bytes());
+            buf.extend_from_slice(b": ");
+            buf.extend_from_slice(&value.as_bytes());
+            buf.extend_from_slice(b"\r\n");
+        }
+        buf.extend_from_slice(b"\r\n");
+        buf
+    }
+}
+
+/// Error that can occur when build SHIORI request.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("method is required")]
+    MissingMethod,
+    #[error("version is required")]
+    MissingVersion,
+    #[error("charset is required")]
+    MissingCharset,
+    #[error("{0}")]
+    InvalidHeaderName(#[from] HeaderNameError),
+    #[error("{0}")]
+    FailedEncodeHeaderValue(#[from] HeaderValueError),
+}
+
+#[derive(Default)]
+struct Parts {
+    method: Option<Method>,
+    version: Option<Version>,
+    headers: HashMap<String, Vec<String>>,
+    charset: Option<Charset>,
+}
+
+/// Builder for SHIORI v3 request.
+pub struct Builder {
+    inner: Result<Parts, Error>,
+}
+
+impl Builder {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Ok(Parts::default()),
+        }
+    }
+
+    /// Build NOTIFY request.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use uka_shiori::types::v3::{Request, Method, Version, HeaderName, Charset};
+    /// #
+    /// let request = Request::builder()
+    ///   .notify(Version::SHIORI_30)
+    ///   .header(HeaderName::SENDER, "Materia")
+    ///   .header(HeaderName::ID, "OnInitialize")
+    ///   .header(HeaderName::REFERENCE0, "Reference0")
+    ///   .charset(Charset::ASCII)
+    ///   .build()
+    ///   .unwrap();
+    /// assert_eq!(request.method(), Method::NOTIFY);
+    /// ```
+    pub fn notify(self, version: Version) -> Self {
+        self.method(Method::NOTIFY).version(version)
+    }
+
+    /// Build GET request.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use uka_shiori::types::v3::{Request, Method, Version, HeaderName, Charset};
+    /// #
+    /// let request = Request::builder()
+    ///   .get(Version::SHIORI_30)
+    ///   .header(HeaderName::SENDER, "Materia")
+    ///   .header(HeaderName::ID, "version")
+    ///   .charset(Charset::ASCII)
+    ///   .build()
+    ///   .unwrap();
+    /// assert_eq!(request.method(), Method::GET);
+    /// ```
+    pub fn get(self, version: Version) -> Self {
+        self.method(Method::GET).version(version)
+    }
+
+    /// Set SHIORI method.
+    pub fn method(self, method: Method) -> Self {
+        self.and_then(|inner| {
+            Ok(Parts {
+                method: Some(method),
+                ..inner
+            })
+        })
+    }
+
+    /// Set SHIORI version.
+    pub fn version(self, version: Version) -> Self {
+        self.and_then(|inner| {
+            Ok(Parts {
+                version: Some(version),
+                ..inner
+            })
+        })
+    }
+
+    /// Set SHIORI header field.
+    pub fn header<K, V>(self, name: K, value: V) -> Self
+    where
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.and_then(|mut inner| {
+            inner
+                .headers
+                .entry(name.into())
+                .or_default()
+                .push(value.into());
+            Ok(inner)
+        })
+    }
+
+    /// Set SHIORI charset.
+    pub fn charset(self, charset: Charset) -> Self {
+        self.and_then(|mut inner| {
+            inner
+                .headers
+                .entry(HeaderName::CHARSET.to_string())
+                .or_default()
+                .push(charset.to_string());
+            if inner.charset.is_some() {
+                Ok(Parts {
+                    headers: inner.headers,
+                    ..inner
+                })
+            } else {
+                Ok(Parts {
+                    charset: Some(charset),
+                    headers: inner.headers,
+                    ..inner
+                })
+            }
+        })
+    }
+
+    /// Build SHIORI request.
+    pub fn build(self) -> Result<Request, Error> {
+        let inner = self.inner?;
+        let charset = inner.charset.ok_or(Error::MissingCharset)?;
+        Ok(Request {
+            method: inner.method.ok_or(Error::MissingMethod)?,
+            version: inner.version.ok_or(Error::MissingVersion)?,
+            headers: inner.headers.iter().fold(
+                Ok(HeaderMap::with_capacity(inner.headers.len())),
+                |acc, (name, value)| {
+                    value.iter().fold(acc, |acc, value| {
+                        let name = HeaderName::from_static(name).map_err(Error::from);
+                        let value = if value.chars().all(|c| c.is_ascii_graphic()) {
+                            HeaderValue::from_static(value).map_err(Error::from)
+                        } else {
+                            HeaderValue::from_static_with_charset(value, charset)
+                                .map_err(Error::from)
+                        };
+                        acc.and_then(|mut headers| {
+                            name.and_then(|name| value.map(|value| (name, value))).map(
+                                |(name, value)| {
+                                    headers.insert(name, value);
+                                    headers
+                                },
+                            )
+                        })
+                    })
+                },
+            )?,
+            charset: inner.charset.ok_or(Error::MissingCharset)?,
+        })
+    }
+
+    fn and_then<F>(self, func: F) -> Self
+    where
+        F: FnOnce(Parts) -> Result<Parts, Error>,
+    {
+        Builder {
+            inner: self.inner.and_then(func),
+        }
+    }
+}

--- a/uka_shiori/src/types/v3/response.rs
+++ b/uka_shiori/src/types/v3/response.rs
@@ -1,0 +1,298 @@
+use crate::types::v3::charset::Charset;
+use crate::types::v3::header::{
+    HeaderMap, HeaderName, HeaderNameError, HeaderValue, HeaderValueError,
+};
+use crate::types::v3::parse::{parse_response, Error as ParseError};
+use crate::types::v3::status::StatusCode;
+use crate::types::v3::version::Version;
+use std::collections::HashMap;
+use uka_util::encode::Error as EncodeError;
+
+/// `Response` is a type that represents an SHIORI v3 request.
+///
+/// `Response` provides a builder to generate types, a parser to generate types from bytes,
+/// and an accessor to the headers defined in the specification.
+///
+/// # Examples
+///
+/// ```rust
+/// # use uka_shiori::types::v3::{Charset, HeaderName, Response, StatusCode, Version};
+/// #
+/// let response = Response::builder()
+///   .version(Version::SHIORI_30)
+///   .status_code(StatusCode::OK)
+///   .header(HeaderName::SENDER, "F.I.R.S.T")
+///   .header(HeaderName::VALUE, "hoge")
+///   .charset(Charset::ASCII)
+///   .build()
+///   .unwrap();
+/// assert_eq!(response.version(), Version::SHIORI_30);
+/// ```
+pub struct Response {
+    pub(crate) version: Version,
+    pub(crate) status_code: StatusCode,
+    pub(crate) headers: HeaderMap,
+    pub(crate) charset: Charset,
+}
+
+impl Response {
+    /// Parse a bytes into a Response.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use uka_shiori::types::v3::{Charset, HeaderName, Response, StatusCode, Version};
+    /// #
+    /// let input = [
+    ///     b"SHIORI/3.0 204 No Content\r\n".to_vec(),
+    ///     b"Sender: F.I.R.S.T\r\n".to_vec(),
+    ///     b"Value: hoge\r\n".to_vec(),
+    ///     b"Charset: UTF-8\r\n".to_vec(),
+    ///     b"\r\n".to_vec(),
+    /// ].concat();
+    /// let response = Response::parse(&input).unwrap();
+    /// assert_eq!(response.version(), Version::SHIORI_30);
+    /// ```
+    pub fn parse(buf: &[u8]) -> Result<Self, ParseError> {
+        parse_response(buf)
+    }
+
+    pub fn builder() -> Builder {
+        Builder::new()
+    }
+
+    /// Returns SHIORI version.
+    pub fn version(&self) -> Version {
+        self.version
+    }
+
+    /// Returns SHIORI status code.
+    pub fn status_code(&self) -> StatusCode {
+        self.status_code
+    }
+
+    /// Returns SHIORI header fields.
+    pub fn headers(&self) -> &HeaderMap {
+        &self.headers
+    }
+
+    /// Returns SHIORI charset.
+    pub fn charset(&self) -> Charset {
+        self.charset
+    }
+
+    /// Sender
+    pub fn sender(&self) -> Option<&HeaderValue> {
+        self.headers.get(&HeaderName::SENDER)
+    }
+
+    /// ID
+    pub fn id(&self) -> Option<&HeaderValue> {
+        self.headers.get(&HeaderName::ID)
+    }
+
+    /// Reference0
+    pub fn reference0(&self) -> Option<&HeaderValue> {
+        self.headers.get(&HeaderName::REFERENCE0)
+    }
+
+    /// Reference1
+    pub fn reference1(&self) -> Option<&HeaderValue> {
+        self.headers.get(&HeaderName::REFERENCE1)
+    }
+
+    /// Reference2
+    pub fn reference2(&self) -> Option<&HeaderValue> {
+        self.headers.get(&HeaderName::REFERENCE2)
+    }
+
+    /// Reference3
+    pub fn reference3(&self) -> Option<&HeaderValue> {
+        self.headers.get(&HeaderName::REFERENCE3)
+    }
+
+    /// Reference4
+    pub fn reference4(&self) -> Option<&HeaderValue> {
+        self.headers.get(&HeaderName::REFERENCE4)
+    }
+
+    /// Reference5
+    pub fn reference5(&self) -> Option<&HeaderValue> {
+        self.headers.get(&HeaderName::REFERENCE5)
+    }
+
+    /// Reference6
+    pub fn reference6(&self) -> Option<&HeaderValue> {
+        self.headers.get(&HeaderName::REFERENCE6)
+    }
+
+    /// Reference7
+    pub fn reference7(&self) -> Option<&HeaderValue> {
+        self.headers.get(&HeaderName::REFERENCE7)
+    }
+
+    /// SecurityLevel
+    pub fn security_level(&self) -> Option<&HeaderValue> {
+        self.headers.get(&HeaderName::SECURITY_LEVEL)
+    }
+
+    /// Value
+    pub fn value(&self) -> Option<&HeaderValue> {
+        self.headers.get(&HeaderName::VALUE)
+    }
+
+    pub fn as_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(self.version.to_string().as_bytes());
+        buf.extend_from_slice(b" ");
+        buf.extend_from_slice(self.status_code.to_string().as_bytes());
+        buf.extend_from_slice(b"\r\n");
+        for (name, value) in self.headers.iter() {
+            buf.extend_from_slice(&name.as_bytes());
+            buf.extend_from_slice(b": ");
+            buf.extend_from_slice(&value.as_bytes());
+            buf.extend_from_slice(b"\r\n");
+        }
+        buf.extend_from_slice(b"\r\n");
+        buf
+    }
+}
+
+/// Error that can occur when build SHIORI response.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("version is required")]
+    MissingVersion,
+    #[error("status_code is required")]
+    MissingStatusCode,
+    #[error("charset is required")]
+    MissingCharset,
+    #[error("{0}")]
+    InvalidHeaderName(#[from] HeaderNameError),
+    #[error("{0}")]
+    FailedEncodeHeaderValue(#[from] HeaderValueError),
+    #[error("{0}")]
+    FailedEncodeAdditionalData(#[from] EncodeError),
+}
+
+#[derive(Default)]
+struct Parts {
+    version: Option<Version>,
+    status_code: Option<StatusCode>,
+    headers: HashMap<String, Vec<String>>,
+    charset: Option<Charset>,
+}
+
+/// Builder for SHIORI response.
+pub struct Builder {
+    inner: Result<Parts, Error>,
+}
+
+impl Builder {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Ok(Parts::default()),
+        }
+    }
+
+    /// Set SHIORI version.
+    pub fn version(self, version: Version) -> Self {
+        self.and_then(|parts| {
+            Ok(Parts {
+                version: Some(version),
+                ..parts
+            })
+        })
+    }
+
+    /// Set SHIORI status code.
+    pub fn status_code(self, status_code: StatusCode) -> Self {
+        self.and_then(|parts| {
+            Ok(Parts {
+                status_code: Some(status_code),
+                ..parts
+            })
+        })
+    }
+
+    /// Set SHIORI header field.
+    pub fn header<K, V>(self, name: K, value: V) -> Self
+    where
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.and_then(|mut inner| {
+            inner
+                .headers
+                .entry(name.into())
+                .or_default()
+                .push(value.into());
+            Ok(inner)
+        })
+    }
+
+    /// Set SHIORI charset.
+    pub fn charset(self, charset: Charset) -> Self {
+        self.and_then(|mut inner| {
+            inner
+                .headers
+                .entry(HeaderName::CHARSET.to_string())
+                .or_default()
+                .push(charset.to_string());
+            if inner.charset.is_some() {
+                Ok(Parts {
+                    headers: inner.headers,
+                    ..inner
+                })
+            } else {
+                Ok(Parts {
+                    charset: Some(charset),
+                    headers: inner.headers,
+                    ..inner
+                })
+            }
+        })
+    }
+
+    /// Build SHIORI response.
+    pub fn build(self) -> Result<Response, Error> {
+        let inner = self.inner?;
+        let charset = inner.charset.ok_or(Error::MissingCharset)?;
+        Ok(Response {
+            version: inner.version.ok_or(Error::MissingVersion)?,
+            status_code: inner.status_code.ok_or(Error::MissingStatusCode)?,
+            headers: inner.headers.iter().fold(
+                Ok(HeaderMap::with_capacity(inner.headers.len())),
+                |acc, (name, value)| {
+                    value.iter().fold(acc, |acc, value| {
+                        let name = HeaderName::from_static(name).map_err(Error::from);
+                        let value = if value.chars().all(|c| c.is_ascii_graphic()) {
+                            HeaderValue::from_static(value).map_err(Error::from)
+                        } else {
+                            HeaderValue::from_static_with_charset(value, charset)
+                                .map_err(Error::from)
+                        };
+                        acc.and_then(|mut headers| {
+                            name.and_then(|name| value.map(|value| (name, value))).map(
+                                |(name, value)| {
+                                    headers.insert(name, value);
+                                    headers
+                                },
+                            )
+                        })
+                    })
+                },
+            )?,
+            charset: inner.charset.ok_or(Error::MissingCharset)?,
+        })
+    }
+
+    fn and_then<F>(self, func: F) -> Self
+    where
+        F: FnOnce(Parts) -> Result<Parts, Error>,
+    {
+        Builder {
+            inner: self.inner.and_then(func),
+        }
+    }
+}

--- a/uka_shiori/src/types/v3/status.rs
+++ b/uka_shiori/src/types/v3/status.rs
@@ -1,0 +1,60 @@
+use std::fmt;
+use std::fmt::Display;
+
+/// StatusCode represents the status code of the SHIORI response.
+///
+/// # Examples
+///
+/// ```rust
+/// # use uka_shiori::types::v3::StatusCode;
+/// assert_eq!(StatusCode::OK.to_string(), "200 OK");
+/// assert_eq!(StatusCode::NO_CONTENT.to_string(), "204 No Content");
+/// assert_eq!(StatusCode::COMMUNICATE.to_string(), "310 Communicate");
+/// assert_eq!(StatusCode::NOT_ENOUGH.to_string(), "311 Not Enough");
+/// assert_eq!(StatusCode::ADVICE.to_string(), "312 Advice");
+/// assert_eq!(StatusCode::BAD_REQUEST.to_string(), "400 Bad Request");
+/// assert_eq!(StatusCode::INTERNAL_SERVER_ERROR.to_string(), "500 Internal Server Error");
+/// ```
+#[derive(Debug, PartialEq, PartialOrd, Copy, Clone, Eq, Ord, Hash)]
+pub struct StatusCode(u16);
+impl StatusCode {
+    // 2xx - Process Completed
+    /// 200 OK
+    pub const OK: StatusCode = StatusCode(200);
+
+    /// 204 No Content
+    pub const NO_CONTENT: StatusCode = StatusCode(204);
+
+    // 3xx - 処理完了、追加アクション要求
+    /// 310 Communicate (deprecated)
+    pub const COMMUNICATE: StatusCode = StatusCode(310);
+
+    /// 311 Not Enough
+    pub const NOT_ENOUGH: StatusCode = StatusCode(311);
+
+    /// 312 Advice
+    pub const ADVICE: StatusCode = StatusCode(312);
+
+    // 4xx - Request Error
+    /// 400 Bad Request
+    pub const BAD_REQUEST: StatusCode = StatusCode(400);
+
+    // 5xx - Server Error
+    /// 500 Internal Server Error
+    pub const INTERNAL_SERVER_ERROR: StatusCode = StatusCode(500);
+}
+
+impl Display for StatusCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            200 => write!(f, "200 OK"),
+            204 => write!(f, "204 No Content"),
+            310 => write!(f, "310 Communicate"),
+            311 => write!(f, "311 Not Enough"),
+            312 => write!(f, "312 Advice"),
+            400 => write!(f, "400 Bad Request"),
+            500 => write!(f, "500 Internal Server Error"),
+            _ => unreachable!("unreachable because StatusCode cannot be new instance"),
+        }
+    }
+}

--- a/uka_shiori/src/types/v3/version.rs
+++ b/uka_shiori/src/types/v3/version.rs
@@ -1,0 +1,42 @@
+use std::fmt;
+
+#[derive(Debug, PartialEq, PartialOrd, Copy, Clone, Eq, Ord, Hash)]
+enum Protocol {
+    SHIORI30,
+}
+
+/// Version is the version of the SHIORI protocol.
+///
+/// # Examples
+///
+/// ```rust
+/// # use uka_shiori::types::v3::Version;
+/// # let version = Version::SHIORI_30;
+/// match version {
+///     Version::SHIORI_30 => assert_eq!(version.to_string(), "SHIORI/3.0"),
+/// }
+/// ```
+#[derive(Debug, PartialEq, PartialOrd, Copy, Clone, Eq, Ord, Hash)]
+pub struct Version(Protocol);
+impl Version {
+    /// SHIORI/3.0
+    pub const SHIORI_30: Version = Version(Protocol::SHIORI30);
+}
+
+impl Default for Version {
+    #[inline]
+    fn default() -> Version {
+        // Default to the latest version
+        Version::SHIORI_30
+    }
+}
+
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use self::Protocol::*;
+
+        f.write_str(match self.0 {
+            SHIORI30 => "SHIORI/3.0",
+        })
+    }
+}

--- a/uka_shiori/tests/extend_spec_shiori_v3.rs
+++ b/uka_shiori/tests/extend_spec_shiori_v3.rs
@@ -1,0 +1,344 @@
+use uka_shiori::types::v3::{Charset, HeaderName};
+use uka_shiori::types::{Request, Response};
+use uka_util::encode::Encoder;
+
+/// This is an extended specification of uka-rs.
+///
+/// `Charset` is not referred to in the SHIORI/3.0 request.
+/// However, to support multi-byte strings, the specification is inherited from SHIORI/2.x to support `Charset`.
+/// The Charset value inherits the specification from SSTP and supports `ASCII`, `Shift_JIS`, `ISO-2022-JP`, `EUC-JP`, and `UTF-8`.
+#[test]
+fn spec_shiori_request_support_charset() -> anyhow::Result<()> {
+    let input = [
+        b"GET SHIORI/3.0\r\n".to_vec(),
+        b"Charset: UTF-8\r\n".to_vec(),
+        b"Sender: ".to_vec(),
+        Encoder::encode_utf8("マテリア")?,
+        b"\r\n".to_vec(),
+        b"ID: hoge\r\n".to_vec(),
+        b"Reference0: uge\r\n".to_vec(),
+        b"\r\n".to_vec(),
+    ]
+    .concat();
+    match Request::parse(&input).unwrap() {
+        Request::V3(request) => {
+            assert_eq!(request.charset(), Charset::UTF8);
+            assert_eq!(
+                request
+                    .sender()
+                    .and_then(|v| v.text_with_charset(Charset::UTF8).ok()),
+                Some("マテリア".to_string())
+            );
+        }
+    };
+
+    Ok(())
+}
+
+/// This is an extended specification of uka-rs.
+///
+/// `Charset` is supported by the uka-rs extended specification, and `Charset` defaults to `ASCII`.
+#[test]
+fn spec_shiori_request_defaults_to_ascii_if_charset_is_omitted() -> anyhow::Result<()> {
+    let input = [
+        b"GET SHIORI/3.0\r\n".to_vec(),
+        b"Sender: Materia\r\n".to_vec(),
+        b"ID: hoge\r\n".to_vec(),
+        b"Reference0: uge\r\n".to_vec(),
+        b"\r\n".to_vec(),
+    ]
+    .concat();
+    match Request::parse(&input)? {
+        Request::V3(request) => {
+            assert_eq!(request.charset(), Charset::ASCII);
+        }
+    };
+
+    Ok(())
+}
+
+/// This is an extended specification of uka-rs.
+///
+/// The behavior when multiple headers are defined that are expected to be one is undefined in `Materia`.
+/// In uka-rs, priority is given to the first header defined in accordance with the HTTP specification.
+#[test]
+fn spec_shiori_request_duplicate_single_headers_can_get_the_first_header() -> anyhow::Result<()> {
+    let input = [
+        b"GET SHIORI/3.0\r\n".to_vec(),
+        b"Sender: Materia\r\n".to_vec(),
+        b"Sender: Uka\r\n".to_vec(),
+        b"ID: hoge\r\n".to_vec(),
+        b"Reference0: uge\r\n".to_vec(),
+        b"\r\n".to_vec(),
+    ]
+    .concat();
+    match Request::parse(&input)? {
+        Request::V3(request) => {
+            assert_eq!(
+                request
+                    .sender()
+                    .and_then(|v| v.text_with_charset(Charset::ASCII).ok()),
+                Some("Materia".to_string())
+            );
+        }
+    };
+    Ok(())
+}
+
+/// This is an extended specification of uka-rs.
+///
+/// The behavior of the header key-value delimiter with no space is undefined in `Materia`.
+/// uka-rs allows no spaces.
+///
+/// e.g. `HeaderName:HeaderValue`
+#[test]
+fn spec_shiori_request_allow_zero_spaces_after_the_header_delimiter() -> anyhow::Result<()> {
+    let input = [
+        b"GET SHIORI/3.0\r\n".to_vec(),
+        b"Sender:Materia\r\n".to_vec(),
+        b"ID:hoge\r\n".to_vec(),
+        b"Reference0:uge\r\n".to_vec(),
+        b"\r\n".to_vec(),
+    ]
+    .concat();
+    match Request::parse(&input)? {
+        Request::V3(request) => {
+            assert_eq!(
+                request
+                    .sender()
+                    .and_then(|v| v.text_with_charset(Charset::ASCII).ok()),
+                Some("Materia".to_string())
+            );
+        }
+    };
+    Ok(())
+}
+
+/// This is an extended specification of uka-rs.
+///
+/// The behavior of the header key-value delimiter with more space is undefined in `Materia`.
+/// uka-rs allows more spaces.
+///
+/// e.g. `HeaderName:  HeaderValue`
+#[test]
+fn spec_shiori_request_allow_one_or_more_spaces_after_the_header_delimiter() -> anyhow::Result<()> {
+    let input = [
+        b"GET SHIORI/3.0\r\n".to_vec(),
+        b"Sender: Materia\r\n".to_vec(),
+        b"ID:  hoge\r\n".to_vec(),
+        b"Reference0:   uge\r\n".to_vec(),
+        b"\r\n".to_vec(),
+    ]
+    .concat();
+    match Request::parse(&input)? {
+        Request::V3(request) => {
+            assert_eq!(
+                request
+                    .sender()
+                    .and_then(|v| v.text_with_charset(Charset::ASCII).ok()),
+                Some("Materia".to_string())
+            );
+        }
+    };
+    Ok(())
+}
+
+/// This is an extended specification of uka-rs.
+///
+/// In Materia, the characters allowed in the header are undefined.
+/// only certain printable characters are allowed according to the HTTP specification.
+#[test]
+fn spec_shiori_request_character_set_for_request_header_names_is_based_on_rfc_7230(
+) -> anyhow::Result<()> {
+    let name = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&'*+-.^_`|~";
+
+    let input = [
+        b"GET SHIORI/3.0\r\n".to_vec(),
+        format!("{name}: Materia\r\n").as_bytes().to_vec(),
+        b"ID: hoge\r\n".to_vec(),
+        b"Reference0: uge\r\n".to_vec(),
+        b"\r\n".to_vec(),
+    ]
+    .concat();
+
+    match Request::parse(&input)? {
+        Request::V3(request) => {
+            assert_eq!(
+                request
+                    .headers()
+                    .get(&HeaderName::from_static(name)?)
+                    .and_then(|v| v.text_with_charset(Charset::ASCII).ok()),
+                Some("Materia".to_string())
+            );
+        }
+    };
+    Ok(())
+}
+
+/// This is an extended specification of uka-rs.
+///
+/// `Charset` is not referred to in the SHIORI/3.0 response.
+/// However, to support multi-byte strings, the specification is inherited from SHIORI/2.x to support `Charset`.
+/// The Charset value inherits the specification from SSTP and supports `ASCII`, `Shift_JIS`, `ISO-2022-JP`, `EUC-JP`, and `UTF-8`.
+#[test]
+fn spec_shiori_response_support_charset() -> anyhow::Result<()> {
+    let input = [
+        b"SHIORI/3.0 200 OK\r\n".to_vec(),
+        b"Charset: UTF-8\r\n".to_vec(),
+        b"Sender: ".to_vec(),
+        Encoder::encode_utf8("マテリア")?,
+        b"\r\n".to_vec(),
+        b"Value: hoge\r\n".to_vec(),
+        b"\r\n".to_vec(),
+    ]
+    .concat();
+    match Response::parse(&input).unwrap() {
+        Response::V3(response) => {
+            assert_eq!(response.charset(), Charset::UTF8);
+            assert_eq!(
+                response
+                    .sender()
+                    .and_then(|v| v.text_with_charset(Charset::UTF8).ok()),
+                Some("マテリア".to_string())
+            );
+        }
+    };
+
+    Ok(())
+}
+
+/// This is an extended specification of uka-rs.
+///
+/// `Charset` is supported by the uka-rs extended specification, and `Charset` defaults to `ASCII`.
+#[test]
+fn spec_shiori_response_defaults_to_ascii_if_charset_is_omitted() -> anyhow::Result<()> {
+    let input = [
+        b"SHIORI/3.0 200 OK\r\n".to_vec(),
+        b"Sender: F.I.R.S.T\r\n".to_vec(),
+        b"Value: hoge\r\n".to_vec(),
+        b"\r\n".to_vec(),
+    ]
+    .concat();
+    match Response::parse(&input)? {
+        Response::V3(response) => {
+            assert_eq!(response.charset(), Charset::ASCII);
+        }
+    };
+
+    Ok(())
+}
+
+/// This is an extended specification of uka-rs.
+///
+/// The behavior when multiple headers are defined that are expected to be one is undefined in `Materia`.
+/// In uka-rs, priority is given to the first header defined in accordance with the HTTP specification.
+#[test]
+fn spec_shiori_response_duplicate_single_headers_can_get_the_first_header() -> anyhow::Result<()> {
+    let input = [
+        b"SHIORI/3.0 200 OK\r\n".to_vec(),
+        b"Sender: F.I.R.S.T\r\n".to_vec(),
+        b"Sender: S.E.C.O.N.D\r\n".to_vec(),
+        b"Value: hoge\r\n".to_vec(),
+        b"\r\n".to_vec(),
+    ]
+    .concat();
+    match Response::parse(&input)? {
+        Response::V3(response) => {
+            assert_eq!(
+                response
+                    .sender()
+                    .and_then(|v| v.text_with_charset(Charset::ASCII).ok()),
+                Some("F.I.R.S.T".to_string())
+            );
+        }
+    };
+    Ok(())
+}
+
+/// This is an extended specification of uka-rs.
+///
+/// The behavior of the header key-value delimiter with no space is undefined in `Materia`.
+/// uka-rs allows no spaces.
+///
+/// e.g. `HeaderName:HeaderValue`
+#[test]
+fn spec_shiori_response_allow_zero_spaces_after_the_header_delimiter() -> anyhow::Result<()> {
+    let input = [
+        b"SHIORI/3.0 200 OK\r\n".to_vec(),
+        b"Sender:F.I.R.S.T\r\n".to_vec(),
+        b"Value:hoge\r\n".to_vec(),
+        b"\r\n".to_vec(),
+    ]
+    .concat();
+    match Response::parse(&input)? {
+        Response::V3(response) => {
+            assert_eq!(
+                response
+                    .sender()
+                    .and_then(|v| v.text_with_charset(Charset::ASCII).ok()),
+                Some("F.I.R.S.T".to_string())
+            );
+        }
+    };
+    Ok(())
+}
+
+/// This is an extended specification of uka-rs.
+///
+/// The behavior of the header key-value delimiter with more space is undefined in `Materia`.
+/// uka-rs allows more spaces.
+///
+/// e.g. `HeaderName:  HeaderValue`
+#[test]
+fn spec_shiori_response_allow_one_or_more_spaces_after_the_header_delimiter() -> anyhow::Result<()>
+{
+    let input = [
+        b"SHIORI/3.0 200 OK\r\n".to_vec(),
+        b"Sender: F.I.R.S.T\r\n".to_vec(),
+        b"Value:   hoge\r\n".to_vec(),
+        b"\r\n".to_vec(),
+    ]
+    .concat();
+    match Response::parse(&input)? {
+        Response::V3(response) => {
+            assert_eq!(
+                response
+                    .value()
+                    .and_then(|v| v.text_with_charset(Charset::ASCII).ok()),
+                Some("hoge".to_string())
+            );
+        }
+    };
+    Ok(())
+}
+
+/// This is an extended specification of uka-rs.
+///
+/// In Materia, the characters allowed in the header are undefined.
+/// only certain printable characters are allowed according to the HTTP specification.
+#[test]
+fn spec_shiori_response_character_set_for_response_header_names_is_based_on_rfc_7230(
+) -> anyhow::Result<()> {
+    let name = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&'*+-.^_`|~";
+
+    let input = [
+        b"SHIORI/3.0 200 OK\r\n".to_vec(),
+        format!("{name}: Materia\r\n").as_bytes().to_vec(),
+        b"Value:   hoge\r\n".to_vec(),
+        b"\r\n".to_vec(),
+    ]
+    .concat();
+
+    match Response::parse(&input)? {
+        Response::V3(response) => {
+            assert_eq!(
+                response
+                    .headers()
+                    .get(&HeaderName::from_static(name)?)
+                    .and_then(|v| v.text_with_charset(Charset::ASCII).ok()),
+                Some("Materia".to_string())
+            );
+        }
+    };
+    Ok(())
+}

--- a/uka_shiori/tests/spec_shiori_v3.rs
+++ b/uka_shiori/tests/spec_shiori_v3.rs
@@ -1,0 +1,147 @@
+use uka_shiori::types::v3::HeaderValue;
+use uka_shiori::types::{v3, Request, Response};
+
+/// http://usada.sakura.vg/contents/specification2.html#shioriprotocol
+/// > リクエスト文字列は以下の形式で構成される。
+/// > ```
+/// > GET SHIORI/3.0
+/// > Sender: Materia
+/// > ID: hoge
+/// > Reference0: uge
+/// > Reference1: ....
+/// > ....
+/// > ..
+/// >
+/// > ```
+/// > 行単位処理の発想であり、CR+LF で各行がセパレートされ、空行でターミネートされる。
+/// > 第1行目はコマンド行であり、コマンド文字列とこのリクエストのバージョンナンバがセットされる。
+/// > 第2行目以降はヘッダ行であり、Key: Value の形式で任意の数のヘッダが続く。
+/// > このヘッダの最大数は無限であり、順不同である。
+#[test]
+fn spec_shiori_request() -> anyhow::Result<()> {
+    let input = [
+        b"GET SHIORI/3.0\r\n".to_vec(),
+        b"Sender: Materia\r\n".to_vec(),
+        b"ID: hoge\r\n".to_vec(),
+        b"Reference0: uge\r\n".to_vec(),
+        b"\r\n".to_vec(),
+    ]
+    .concat();
+    match Request::parse(&input)? {
+        Request::V3(request) => {
+            assert_eq!(request.method(), v3::Method::GET);
+            assert_eq!(request.version(), v3::Version::SHIORI_30);
+            assert_eq!(
+                request.sender(),
+                Some(&HeaderValue::from(b"Materia".as_slice()))
+            );
+            assert_eq!(request.id(), Some(&HeaderValue::from(b"hoge".as_slice())));
+            assert_eq!(
+                request.reference0(),
+                Some(&HeaderValue::from(b"uge".as_slice()))
+            );
+
+            assert_eq!(
+                request.as_bytes(),
+                input,
+                "\nassertion failed: `(left == right)\n  left: `{:?}`,\n right: `{:?}`",
+                String::from_utf8_lossy(&request.as_bytes()),
+                String::from_utf8_lossy(&input)
+            );
+        }
+    };
+
+    Ok(())
+}
+
+/// http://usada.sakura.vg/contents/specification2.html#shioriprotocol
+/// > レスポンス文字列は以下の形式で構成される。
+/// > ```
+/// > SHIORI/3.0 200 OK
+/// > Sender: F.I.R.S.T
+/// > Value: hoge
+/// > ....
+/// > ..
+/// >
+/// > ```
+/// > 1行目はリザルトコード行であり、このレスポンスのバージョンナンバとリザルトコードがセットされる。他はリクエスト文字列と全く同じ。
+#[test]
+fn spec_shiori_response() -> anyhow::Result<()> {
+    let input = [
+        b"SHIORI/3.0 200 OK\r\n".to_vec(),
+        b"Sender: F.I.R.S.T\r\n".to_vec(),
+        b"Value: hoge\r\n".to_vec(),
+        b"\r\n".to_vec(),
+    ]
+    .concat();
+
+    match Response::parse(&input)? {
+        Response::V3(response) => {
+            assert_eq!(response.version(), v3::Version::SHIORI_30);
+            assert_eq!(response.status_code(), v3::StatusCode::OK);
+            assert_eq!(
+                response.sender(),
+                Some(&HeaderValue::from(b"F.I.R.S.T".as_slice()))
+            );
+            assert_eq!(
+                response.value(),
+                Some(&HeaderValue::from(b"hoge".as_slice()))
+            );
+
+            assert_eq!(
+                response.as_bytes(),
+                input,
+                "\nassertion failed: `(left == right)\n  left: `{:?}`,\n right: `{:?}`",
+                String::from_utf8_lossy(&response.as_bytes()),
+                String::from_utf8_lossy(&input)
+            );
+        }
+    };
+
+    Ok(())
+}
+
+/// http://usada.sakura.vg/contents/specification2.html#shioriprotocol
+/// > レスポンスの Reference0 が話し掛ける相手の名前を表す。
+/// >
+/// > 異常な仕様だが他によい方法が思いつかないので暫定的にこの位置に置く。
+#[test]
+fn spec_shiori_response_with_name_of_person_to_talk_to() -> anyhow::Result<()> {
+    let input = [
+        b"SHIORI/3.0 200 OK\r\n".to_vec(),
+        b"Sender: F.I.R.S.T\r\n".to_vec(),
+        b"Value: hoge\r\n".to_vec(),
+        b"Reference0: Sakura\r\n".to_vec(),
+        b"\r\n".to_vec(),
+    ]
+    .concat();
+
+    match Response::parse(&input)? {
+        Response::V3(response) => {
+            assert_eq!(response.version(), v3::Version::SHIORI_30);
+            assert_eq!(response.status_code(), v3::StatusCode::OK);
+            assert_eq!(
+                response.sender(),
+                Some(&HeaderValue::from(b"F.I.R.S.T".as_slice()))
+            );
+            assert_eq!(
+                response.value(),
+                Some(&HeaderValue::from(b"hoge".as_slice()))
+            );
+            assert_eq!(
+                response.reference0(),
+                Some(&HeaderValue::from(b"Sakura".as_slice()))
+            );
+
+            assert_eq!(
+                response.as_bytes(),
+                input,
+                "\nassertion failed: `(left == right)\n  left: `{:?}`,\n right: `{:?}`",
+                String::from_utf8_lossy(&response.as_bytes()),
+                String::from_utf8_lossy(&input)
+            );
+        }
+    };
+
+    Ok(())
+}

--- a/uka_util/src/bag.rs
+++ b/uka_util/src/bag.rs
@@ -119,6 +119,16 @@ impl<K: Eq + Hash, V> OrderedBag<K, V> {
         self.map.entry(k).or_default().push(pos);
     }
 
+    /// Returns the number of elements in the bag.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns true if the bag contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
     /// Returns an iterator over the bag.
     /// The iterator will yield tuples in the order they were inserted into the bag.
     ///
@@ -154,6 +164,16 @@ impl<K: Eq + Hash + Clone, V> From<Vec<(K, V)>> for OrderedBag<K, V> {
     fn from(entries: Vec<(K, V)>) -> Self {
         let mut bag = Self::with_capacity(entries.len());
         for (k, v) in entries {
+            bag.insert(k, v);
+        }
+        bag
+    }
+}
+
+impl<K: Eq + Hash + Clone, V> FromIterator<(K, V)> for OrderedBag<K, V> {
+    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
+        let mut bag = Self::new();
+        for (k, v) in iter {
             bag.insert(k, v);
         }
         bag


### PR DESCRIPTION
add SHIORI/3.0 types.

Specification:
- http://usada.sakura.vg/contents/specification2.html#shioriprotocol
- http://usada.sakura.vg/contents/shiori.html
- https://ssp.shillest.net/ukadoc/manual/spec_shiori3.html

NOTE: SHIORI/3.0 SSP extensions are not supported