### PR TITLE
Add SHIORI Runtime

### DIFF
--- a/uka_shiori/Cargo.toml
+++ b/uka_shiori/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 thiserror = "1.0.40"
+tokio = { version = "1.28.2", features = ["full"] }
 uka_util = { path = "../uka_util" }
 
 [dev-dependencies]

--- a/uka_shiori/src/lib.rs
+++ b/uka_shiori/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod runtime;
 pub mod types;

--- a/uka_shiori/src/runtime.rs
+++ b/uka_shiori/src/runtime.rs
@@ -1,0 +1,9 @@
+mod context;
+mod error;
+mod service;
+mod shiori;
+
+pub use context::{Context, ContextData};
+pub use error::{ShioriError, ShioriErrorContext};
+pub use service::{box_handler, handler, BoxAsyncFn, Service, ShioriHandler};
+pub use shiori::Shiori;

--- a/uka_shiori/src/runtime/context.rs
+++ b/uka_shiori/src/runtime/context.rs
@@ -1,0 +1,99 @@
+use std::ops::Deref;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+/// The `ContextData` trait represents shared data that is accessible during the handling of each request.
+///
+/// Types implementing this trait are used to carry information that is available
+/// throughout the lifetime of a SHIORI runtime service. This is typically used
+/// to store configuration data, shared resources, or any other kind of data that
+/// needs to be accessed across multiple requests.
+///
+/// `ContextData` provides a way to customize what data is stored and accessed during
+/// the processing of a request. For instance, it could be used to hold a connection
+/// pool, configuration parameters, or any other kind of shared resource.
+///
+/// # Examples
+///
+/// ```rust
+/// # use uka_shiori::runtime::ContextData;
+/// # use std::path::PathBuf;
+/// #
+/// pub struct ShioriContext {
+///     pub base_dir: PathBuf,
+/// }
+///
+/// impl ShioriContext {
+///     pub fn base_dir(&self) -> &PathBuf {
+///         &self.base_dir
+///     }
+/// }
+///
+/// impl ContextData for ShioriContext {
+///     type Error = std::io::Error;
+///
+///     fn new(path: PathBuf) -> Result<Self, Self::Error> {
+///         Ok(Self { base_dir: path })
+///     }
+/// }
+///
+/// impl Drop for ShioriContext {
+///     fn drop(&mut self) {
+///         // ShioriContext does nothing.
+///     }
+/// }
+///
+/// let path = PathBuf::from("C:\\ghost\\");
+/// let data = ShioriContext::new(path.clone()).unwrap();
+/// let context = uka_shiori::runtime::Context::new(data);
+///
+/// assert_eq!(context.base_dir(), &path);
+/// ```
+pub trait ContextData: Sized + Send + Sync {
+    type Error;
+
+    /// Constructs a new instance of a type implementing `ContextData`.
+    ///
+    /// The argument `path` is passed as the ghost directory path.
+    /// The ghost directory path in the case of `path` is the directory where the DLL files are located.
+    fn new(path: PathBuf) -> Result<Self, Self::Error>;
+}
+
+/// `Context<T>` is the wrapper for data of type `T` that implements the `ContextData` trait.
+///
+/// This structure provides a way to carry context-specific data during the handling of a request.
+/// It's designed to be used with types implementing the `ContextData` trait, allowing
+/// access to shared data during request processing.
+pub struct Context<T: ContextData> {
+    inner: Arc<T>,
+}
+
+impl<T: ContextData> Context<T> {
+    pub fn new(value: T) -> Self {
+        Self {
+            inner: Arc::new(value),
+        }
+    }
+}
+
+impl<T: ContextData> Clone for Context<T> {
+    fn clone(&self) -> Self {
+        Context {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<T: ContextData> Deref for Context<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner.deref()
+    }
+}
+
+impl<T: ContextData> From<T> for Context<T> {
+    fn from(value: T) -> Self {
+        Context::new(value)
+    }
+}

--- a/uka_shiori/src/runtime/error.rs
+++ b/uka_shiori/src/runtime/error.rs
@@ -1,0 +1,227 @@
+use std::fmt::{Debug, Display, Formatter};
+use std::ops::Deref;
+
+/// `ShioriError` is a custom error type used across the SHIORI service.
+///
+/// This structure provides a standardized way to wrap and handle various
+/// kinds of errors that may occur during the processing of a SHIORI request.
+/// It encapsulates a source error and optionally provides additional context information.
+pub struct ShioriError {
+    /// The source error which is wrapped by `ShioriError`.
+    source: Box<dyn std::error::Error + Send + Sync>,
+
+    /// Optional context information associated with the error.
+    context: Option<String>,
+}
+
+impl ShioriError {
+    /// Constructs a new `ShioriError` by wrapping an error object.
+    ///
+    /// The provided error is stored as the source error of the `ShioriError`.
+    /// The source error must implement the `Error` trait and be thread safe.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use uka_shiori::runtime::ShioriError;
+    /// #
+    /// let e = ShioriError::new("something went wrong");
+    /// assert_eq!(format!("{e}"), "something went wrong");
+    /// ```
+    pub fn new(e: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> Self {
+        Self {
+            source: e.into(),
+            context: None,
+        }
+    }
+
+    /// Creates a new `ShioriError` from a specific source error.
+    ///
+    /// This is similar to the `new` method, but allows for more specific type
+    /// information on the source error.
+    pub fn source<E: std::error::Error + Send + Sync + 'static>(error: E) -> Self {
+        Self {
+            source: Box::new(error),
+            context: None,
+        }
+    }
+
+    /// Attaches a context message to the `ShioriError`.
+    ///
+    /// If there is an existing context, the new context will be appended to it.
+    /// The context message can help provide additional information about where or
+    /// why the error occurred.
+    pub(crate) fn context<C: Display>(mut self, context: C) -> Self {
+        match self.context {
+            Some(ref mut c) => {
+                c.push_str(": ");
+                c.push_str(&context.to_string());
+            }
+            None => {
+                self.context = Some(context.to_string());
+            }
+        };
+        self
+    }
+}
+
+impl Deref for ShioriError {
+    type Target = dyn std::error::Error + Send + Sync;
+
+    fn deref(&self) -> &Self::Target {
+        self.source.as_ref()
+    }
+}
+
+impl Display for ShioriError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match &self.context {
+            Some(c) => {
+                let e = self.source.deref();
+                write!(f, "{c}: {e}")
+            }
+            None => {
+                let e = self.source.deref();
+                write!(f, "{e}")
+            }
+        }
+    }
+}
+
+impl Debug for ShioriError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match &self.context {
+            Some(c) => {
+                let e = self.source.deref();
+                write!(f, "{c}: {e:?}")
+            }
+            None => {
+                let e = self.source.deref();
+                write!(f, "{e:?}")
+            }
+        }
+    }
+}
+
+impl<E> From<E> for ShioriError
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    fn from(value: E) -> Self {
+        ShioriError::source(value)
+    }
+}
+
+impl From<ShioriError> for Box<dyn std::error::Error + Send + Sync> {
+    fn from(value: ShioriError) -> Self {
+        value.source
+    }
+}
+
+impl From<ShioriError> for Box<dyn std::error::Error + Send> {
+    fn from(value: ShioriError) -> Self {
+        value.source
+    }
+}
+
+impl From<ShioriError> for Box<dyn std::error::Error + Sync> {
+    fn from(value: ShioriError) -> Self {
+        value.source
+    }
+}
+
+impl From<ShioriError> for Box<dyn std::error::Error> {
+    fn from(value: ShioriError) -> Self {
+        value.source
+    }
+}
+
+/// `ShioriErrorContext` provides extension methods to attach additional context information
+/// to the `ShioriError`.
+///
+/// This trait is used to enrich `ShioriError` instances with extra context information,
+/// which can be useful for debugging and error reporting.
+pub trait ShioriErrorContext {
+    /// Attaches a context message to the `ShioriError`.
+    ///
+    /// This message is displayed alongside the original error message.
+    fn context(self, context: impl Into<String>) -> Self;
+
+    /// Attaches a context message to the `ShioriError`, where the context is produced by a function.
+    ///
+    /// This method can be useful when the context information requires some computation
+    /// to produce, as the function will only be called if there is an error.
+    fn with_context<F, I>(self, f: F) -> Self
+    where
+        F: FnOnce() -> I,
+        I: Into<String>;
+}
+
+impl<T> ShioriErrorContext for Result<T, ShioriError> {
+    fn context(self, context: impl Into<String>) -> Self {
+        self.map_err(|e| e.context(context.into()))
+    }
+
+    fn with_context<F, I>(self, f: F) -> Self
+    where
+        F: FnOnce() -> I,
+        I: Into<String>,
+    {
+        self.map_err(|e| e.context(f().into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(thiserror::Error, Debug)]
+    #[error("Test error")]
+    struct TestError;
+
+    #[test]
+    fn test_service_error_new() {
+        let e = ShioriError::new("Test error");
+        assert_eq!(e.to_string(), "Test error");
+    }
+
+    #[test]
+    fn test_service_error_source() {
+        let e = ShioriError::source(TestError);
+        assert_eq!(e.to_string(), "Test error");
+    }
+
+    #[test]
+    fn test_service_error_context() {
+        let r: Result<(), ShioriError> =
+            Err(ShioriError::source(TestError)).context("Extra context");
+        assert!(r.is_err());
+
+        let e = r.unwrap_err();
+        assert_eq!(format!("{e}"), "Extra context: Test error");
+    }
+
+    #[test]
+    fn test_service_error_with_context() {
+        let r: Result<(), ShioriError> =
+            Err(ShioriError::new(TestError)).with_context(|| "Some context from closure");
+
+        let e = r.unwrap_err();
+        assert_eq!(format!("{e}"), "Some context from closure: Test error");
+    }
+
+    #[test]
+    fn test_service_error_set_multiple_contexts() {
+        let e = ShioriError::new(TestError)
+            .context("First context")
+            .context("Second context");
+        assert_eq!(e.to_string(), "First context: Second context: Test error");
+    }
+
+    #[test]
+    fn test_display_and_debug() {
+        let e = ShioriError::new(TestError).context("Extra context");
+        assert_eq!(format!("{e}"), "Extra context: Test error");
+        assert_eq!(format!("{e:?}"), "Extra context: TestError");
+    }
+}

--- a/uka_shiori/src/runtime/service.rs
+++ b/uka_shiori/src/runtime/service.rs
@@ -1,0 +1,276 @@
+use crate::runtime::context::{Context, ContextData};
+use crate::runtime::error::ShioriError;
+use crate::types::{Request, Response};
+use std::future::Future;
+use std::pin::Pin;
+
+/// `Service<C, R>` is the trait defining an interface for implementing SHIORI runtime services.
+///
+/// Services implementing this trait should be capable of processing incoming requests
+/// according to the SHIORI protocol. `C` represents context-specific data, while `R`
+/// denotes the request type.
+///
+/// `Response`, `Error` and `Future` associated types define the service's response,
+/// potential error, and the future of the result respectively.
+pub trait Service<C, R>
+where
+    C: ContextData,
+{
+    type Response;
+    type Error;
+    type Future: Future<Output = Result<Self::Response, Self::Error>>;
+
+    /// Process an incoming SHIORI protocol request.
+    ///
+    /// Given the runtime context and an incoming request, this method should
+    /// provide the logic for handling the request and produce a future
+    /// that results in either a service response or an error.
+    fn call(&self, context: Context<C>, request: R) -> Self::Future;
+}
+
+/// `ShioriHandler<F>` is a handler for SHIORI runtime services that implements `Service<C, Request>`.
+///
+/// This struct provides a convenient way to wrap a function that can process requests
+/// into a handler, which can be used by a server or other components to handle requests.
+pub struct ShioriHandler<F> {
+    /// The function responsible for handling incoming requests.
+    ///
+    /// This function should be capable of processing SHIORI protocol requests,
+    /// and it should return a future that results in either a service response or an error.
+    handle: F,
+}
+
+impl<C, F, Fut> Service<C, Request> for ShioriHandler<F>
+where
+    C: ContextData,
+    F: Fn(Context<C>, Request) -> Fut,
+    Fut: Future<Output = Result<Response, ShioriError>>,
+{
+    type Response = Response;
+    type Error = ShioriError;
+    type Future = Fut;
+
+    fn call(&self, context: Context<C>, request: Request) -> Self::Future {
+        (self.handle)(context, request)
+    }
+}
+
+/// This function provides a convenient way to construct a `ShioriHandler` from a function.
+///
+/// The input function `f` should take a runtime context and a SHIORI protocol request as
+/// arguments, and return a future that results in either a service response or an error.
+///
+/// The created handler can be used by a server or other components to handle incoming
+/// SHIORI protocol requests.
+pub fn handler<C, F, Fut>(f: F) -> ShioriHandler<F>
+where
+    C: ContextData,
+    F: Fn(Context<C>, Request) -> Fut,
+    Fut: Future<Output = Result<Response, ShioriError>>,
+{
+    ShioriHandler { handle: f }
+}
+
+pub type BoxAsyncFn<C> = Box<
+    dyn Fn(Context<C>, Request) -> Pin<Box<dyn Future<Output = Result<Response, ShioriError>>>>,
+>;
+
+/// Provides a convenient way to construct a `ShioriHandler` from a function, and wraps the function in a `Box`.
+///
+/// This is used over `handler` when you need to store the handler in a `OnceCell` or similar structures
+pub fn box_handler<C, F, Fut>(f: F) -> ShioriHandler<BoxAsyncFn<C>>
+where
+    C: ContextData,
+    F: Fn(Context<C>, Request) -> Fut + 'static,
+    Fut: Future<Output = Result<Response, ShioriError>> + 'static,
+{
+    ShioriHandler {
+        handle: Box::new(move |ctx, req| Box::pin(f(ctx, req))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{v3, RequestExt, ResponseExt};
+    use std::path::PathBuf;
+
+    struct Data;
+    impl ContextData for Data {
+        type Error = ();
+
+        fn new(_path: PathBuf) -> Result<Self, Self::Error> {
+            Ok(Self)
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handler_with_closure() -> Result<(), ShioriError> {
+        let handler = handler(|_ctx: Context<Data>, _req: Request| async {
+            let resp = Response::builder(v3::Version::SHIORI_30)
+                .status_code(v3::StatusCode::OK)
+                .build()?;
+            Ok(resp.into())
+        });
+
+        let ctx = Context::from(Data);
+        let req = Request::builder(v3::Version::SHIORI_30)
+            .method(v3::Method::GET)
+            .header(v3::HeaderName::CHARSET, v3::Charset::UTF8.to_string())
+            .build()?;
+        let resp = handler.call(ctx, req.into()).await?;
+        match resp {
+            Response::V3(r) => {
+                assert_eq!(r.version(), v3::Version::SHIORI_30);
+                assert_eq!(r.status_code(), v3::StatusCode::OK);
+            }
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_handler_with_fn() -> Result<(), ShioriError> {
+        #[allow(clippy::manual_async_fn)]
+        fn handle(
+            _ctx: Context<Data>,
+            _req: Request,
+        ) -> impl Future<Output = Result<Response, ShioriError>> {
+            async {
+                let resp = Response::builder(v3::Version::SHIORI_30)
+                    .status_code(v3::StatusCode::OK)
+                    .build()?;
+                Ok(resp.into())
+            }
+        }
+
+        let handler = handler(handle);
+
+        let ctx = Context::from(Data);
+        let req = Request::builder(v3::Version::SHIORI_30)
+            .method(v3::Method::GET)
+            .header(v3::HeaderName::CHARSET, v3::Charset::UTF8.to_string())
+            .build()?;
+        let resp = handler.call(ctx, req.into()).await?;
+        match resp {
+            Response::V3(r) => {
+                assert_eq!(r.version(), v3::Version::SHIORI_30);
+                assert_eq!(r.status_code(), v3::StatusCode::OK);
+            }
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_handler_with_async_fn() -> Result<(), ShioriError> {
+        async fn handle(_ctx: Context<Data>, _req: Request) -> Result<Response, ShioriError> {
+            let resp = Response::builder(v3::Version::SHIORI_30)
+                .status_code(v3::StatusCode::OK)
+                .build()?;
+            Ok(resp.into())
+        }
+
+        let handler = handler(handle);
+
+        let ctx = Context::from(Data);
+        let req = Request::builder(v3::Version::SHIORI_30)
+            .method(v3::Method::GET)
+            .header(v3::HeaderName::CHARSET, v3::Charset::UTF8.to_string())
+            .build()?;
+        let resp = handler.call(ctx, req.into()).await?;
+        match resp {
+            Response::V3(r) => {
+                assert_eq!(r.version(), v3::Version::SHIORI_30);
+                assert_eq!(r.status_code(), v3::StatusCode::OK);
+            }
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_box_handler_with_closure() -> Result<(), ShioriError> {
+        let handler = box_handler(|_ctx: Context<Data>, _req: Request| async {
+            let resp = Response::builder(v3::Version::SHIORI_30)
+                .status_code(v3::StatusCode::OK)
+                .build()?;
+            Ok(resp.into())
+        });
+
+        let ctx = Context::from(Data);
+        let req = Request::builder(v3::Version::SHIORI_30)
+            .method(v3::Method::GET)
+            .header(v3::HeaderName::CHARSET, v3::Charset::UTF8.to_string())
+            .build()?;
+        let resp = handler.call(ctx, req.into()).await?;
+        match resp {
+            Response::V3(r) => {
+                assert_eq!(r.version(), v3::Version::SHIORI_30);
+                assert_eq!(r.status_code(), v3::StatusCode::OK);
+            }
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_box_handler_with_fn() -> Result<(), ShioriError> {
+        #[allow(clippy::manual_async_fn)]
+        fn handle(
+            _ctx: Context<Data>,
+            _req: Request,
+        ) -> impl Future<Output = Result<Response, ShioriError>> {
+            async {
+                let resp = Response::builder(v3::Version::SHIORI_30)
+                    .status_code(v3::StatusCode::OK)
+                    .build()?;
+                Ok(resp.into())
+            }
+        }
+
+        let handler = box_handler(handle);
+
+        let ctx = Context::from(Data);
+        let req = Request::builder(v3::Version::SHIORI_30)
+            .method(v3::Method::GET)
+            .header(v3::HeaderName::CHARSET, v3::Charset::UTF8.to_string())
+            .build()?;
+        let resp = handler.call(ctx, req.into()).await?;
+        match resp {
+            Response::V3(r) => {
+                assert_eq!(r.version(), v3::Version::SHIORI_30);
+                assert_eq!(r.status_code(), v3::StatusCode::OK);
+            }
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_box_handler_with_async_fn() -> Result<(), ShioriError> {
+        async fn handle(_ctx: Context<Data>, _req: Request) -> Result<Response, ShioriError> {
+            let resp = Response::builder(v3::Version::SHIORI_30)
+                .status_code(v3::StatusCode::OK)
+                .build()?;
+            Ok(resp.into())
+        }
+
+        let handler = box_handler(handle);
+
+        let ctx = Context::from(Data);
+        let req = Request::builder(v3::Version::SHIORI_30)
+            .method(v3::Method::GET)
+            .header(v3::HeaderName::CHARSET, v3::Charset::UTF8.to_string())
+            .build()?;
+        let resp = handler.call(ctx, req.into()).await?;
+        match resp {
+            Response::V3(r) => {
+                assert_eq!(r.version(), v3::Version::SHIORI_30);
+                assert_eq!(r.status_code(), v3::StatusCode::OK);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/uka_shiori/src/runtime/shiori.rs
+++ b/uka_shiori/src/runtime/shiori.rs
@@ -1,0 +1,232 @@
+use crate::runtime::context::{Context, ContextData};
+use crate::runtime::error::ShioriError;
+use crate::runtime::service::Service;
+use crate::types::{Request, Response};
+use std::future::Future;
+use std::ops::Deref;
+use std::path::PathBuf;
+use tokio::sync::RwLock;
+
+/// `Shiori<C, S>` represents the SHIORI runtime.
+///
+/// The runtime is responsible for managing and executing services that handle
+/// SHIORI protocol requests. `C` represents context-specific data and `S` represents the service.
+pub struct Shiori<C, S>
+where
+    C: ContextData<Error = ShioriError>,
+    S: Service<C, Request, Response = Response, Error = ShioriError>,
+{
+    /// Shared context data, which is available to the service during the processing of requests.
+    context: RwLock<Option<Context<C>>>,
+
+    /// The service that handles incoming SHIORI protocol requests.
+    service: S,
+}
+
+impl<C, S, Fut> Shiori<C, S>
+where
+    C: ContextData<Error = ShioriError>,
+    S: Service<C, Request, Response = Response, Error = ShioriError, Future = Fut>,
+    Fut: Future<Output = Result<Response, ShioriError>>,
+{
+    /// Initialize the SHIORI runtime by loading context data from the provided path.
+    ///
+    /// In accordance with SHIORI protocol, if there are any associated data files, they should be
+    /// located at this path. This method must be called before processing any requests.
+    pub async fn load(&self, path: PathBuf) -> Result<(), ShioriError> {
+        let mut context = self.context.write().await;
+        match context.deref() {
+            Some(_) => Err(ShioriError::new("context already loaded")),
+            None => {
+                let data = C::new(path)?;
+                context.replace(data.into());
+
+                Ok(())
+            }
+        }
+    }
+
+    /// Unload the context, removing all the context data.
+    ///
+    /// After this method is called, no requests can be processed until the context is loaded again.
+    pub async fn unload(&self) -> Result<(), ShioriError> {
+        let mut context = self.context.write().await;
+        match context.deref() {
+            Some(_) => {
+                context.take();
+                Ok(())
+            }
+            None => Err(ShioriError::new("context not loaded")),
+        }
+    }
+
+    /// Process a SHIORI protocol request.
+    ///
+    /// This method accepts a request, passes it to the service for processing, and returns the
+    /// service's response. The context must be loaded before this method is called.
+    pub async fn request(&self, request: Request) -> Result<Response, ShioriError> {
+        let ctx = self.context.read().await;
+        match ctx.deref() {
+            Some(ctx) => self.service.call(ctx.clone(), request).await,
+            None => Err(ShioriError::new("context not loaded")),
+        }
+    }
+}
+
+impl<C, S> From<S> for Shiori<C, S>
+where
+    C: ContextData<Error = ShioriError>,
+    S: Service<C, Request, Response = Response, Error = ShioriError>,
+{
+    fn from(value: S) -> Self {
+        Self {
+            context: RwLock::new(None),
+            service: value,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::handler;
+    use crate::types::{v3, RequestExt, ResponseExt};
+
+    struct ShioriContext {
+        path: PathBuf,
+    }
+    impl ShioriContext {
+        fn path(&self) -> &PathBuf {
+            &self.path
+        }
+    }
+    impl ContextData for ShioriContext {
+        type Error = ShioriError;
+
+        fn new(path: PathBuf) -> Result<Self, ShioriError> {
+            Ok(Self { path })
+        }
+    }
+
+    #[tokio::test]
+    async fn test_load() -> Result<(), ShioriError> {
+        let shiori = Shiori::from(handler(
+            |_ctx: Context<ShioriContext>, _req: Request| async { unimplemented!() },
+        ));
+
+        let result = shiori.load(PathBuf::from(".")).await;
+        assert!(result.is_ok());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_load_failed_call_after_load() -> Result<(), ShioriError> {
+        let shiori = Shiori::from(handler(
+            |_ctx: Context<ShioriContext>, _req: Request| async { unimplemented!() },
+        ));
+
+        let result = shiori.load(PathBuf::from(".")).await;
+        assert!(result.is_ok());
+
+        let result = shiori.load(PathBuf::from(".")).await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "context already loaded");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_unload() -> Result<(), ShioriError> {
+        let shiori = Shiori::from(handler(
+            |_ctx: Context<ShioriContext>, _req: Request| async { unimplemented!() },
+        ));
+
+        shiori.load(PathBuf::from(".")).await?;
+
+        let result = shiori.unload().await;
+        assert!(result.is_ok());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_unload_failed_not_call_load() -> Result<(), ShioriError> {
+        let shiori = Shiori::from(handler(
+            |_ctx: Context<ShioriContext>, _req: Request| async { unimplemented!() },
+        ));
+
+        let result = shiori.unload().await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "context not loaded");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_request() -> Result<(), ShioriError> {
+        let shiori = Shiori::from(handler(
+            |ctx: Context<ShioriContext>, req: Request| async move {
+                assert_eq!(ctx.path(), &PathBuf::from("."));
+                matches!(req, Request::V3(ref r) if r.version() == v3::Version::SHIORI_30);
+                matches!(req, Request::V3(ref r) if r.method() == v3::Method::GET);
+
+                let resp = Response::builder(v3::Version::SHIORI_30)
+                    .status_code(v3::StatusCode::OK)
+                    .build()?;
+                Ok(resp.into())
+            },
+        ));
+
+        shiori.load(PathBuf::from(".")).await?;
+
+        let request = Request::builder(v3::Version::SHIORI_30)
+            .method(v3::Method::GET)
+            .charset(v3::Charset::UTF8)
+            .build()?;
+        let response = shiori.request(request.into()).await?;
+
+        matches!(response, Response::V3(ref r) if r.version() == v3::Version::SHIORI_30);
+        matches!(response, Response::V3(ref r) if r.status_code() == v3::StatusCode::OK);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_request_failed_not_call_load() -> Result<(), ShioriError> {
+        let shiori = Shiori::from(handler(
+            |_ctx: Context<ShioriContext>, _req: Request| async { unimplemented!() },
+        ));
+
+        let request = Request::builder(v3::Version::SHIORI_30)
+            .method(v3::Method::GET)
+            .charset(v3::Charset::UTF8)
+            .build()?;
+        let result = shiori.request(request.into()).await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "context not loaded");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_request_failed_handle_error() -> Result<(), ShioriError> {
+        let shiori = Shiori::from(handler(
+            |_ctx: Context<ShioriContext>, _req: Request| async {
+                Err(ShioriError::new("handler error"))
+            },
+        ));
+
+        shiori.load(PathBuf::from(".")).await?;
+
+        let request = Request::builder(v3::Version::SHIORI_30)
+            .method(v3::Method::GET)
+            .charset(v3::Charset::UTF8)
+            .build()?;
+        let result = shiori.request(request.into()).await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "handler error");
+
+        Ok(())
+    }
+}

--- a/uka_shiori/src/types/request.rs
+++ b/uka_shiori/src/types/request.rs
@@ -13,6 +13,7 @@ pub enum RequestParseError {
 ///
 /// This type supports multiple versions of SHIORI.
 /// If you want to support only a specific version, use `uka_shiori::types::v3::Request` and a specific version explicitly.
+#[derive(Debug)]
 pub enum Request {
     V3(v3::Request),
 }

--- a/uka_shiori/src/types/response.rs
+++ b/uka_shiori/src/types/response.rs
@@ -13,6 +13,7 @@ pub enum ResponseParseError {
 ///
 /// This type supports multiple versions of SHIORI.
 /// If you want to support only a specific version, use `uka_shiori::types::v3::Response` and a specific version explicitly.
+#[derive(Debug)]
 pub enum Response {
     V3(v3::Response),
 }

--- a/uka_shiori/src/types/v3/request.rs
+++ b/uka_shiori/src/types/v3/request.rs
@@ -26,6 +26,7 @@ use uka_util::bag::OrderedBag;
 ///     .unwrap();
 /// assert_eq!(request.method(), Method::GET);
 /// ```
+#[derive(Debug)]
 pub struct Request {
     pub(crate) method: Method,
     pub(crate) version: Version,

--- a/uka_shiori/src/types/v3/response.rs
+++ b/uka_shiori/src/types/v3/response.rs
@@ -28,6 +28,7 @@ use uka_util::encode::Error as EncodeError;
 ///   .unwrap();
 /// assert_eq!(response.version(), Version::SHIORI_30);
 /// ```
+#[derive(Debug)]
 pub struct Response {
     pub(crate) version: Version,
     pub(crate) status_code: StatusCode,


### PR DESCRIPTION
PR Type:
**Enhancement**

___
PR Description:
**This PR introduces the SHIORI runtime to the project. The runtime is responsible for managing and executing services that handle SHIORI protocol requests. It also includes a custom error type used across the SHIORI service.**

___
PR Main Files Walkthrough:
-`runtime/service.rs`: Defines the `Service` trait for implementing SHIORI runtime services and provides a convenient way to wrap a function that can process requests into a handler.
-`runtime/shiori.rs`: Represents the SHIORI runtime, responsible for managing and executing services that handle SHIORI protocol requests.
-`runtime/error.rs`: Introduces a custom error type `ShioriError` used across the SHIORI service. This structure provides a standardized way to wrap and handle various kinds of errors that may occur during the processing of a SHIORI request.
