### PR TITLE
fixes STATUS_ACCESS_VIOLATION on x86_64-pc-windows-msvc

### DIFF
--- a/uka_shiori/src/dll/adapter.rs
+++ b/uka_shiori/src/dll/adapter.rs
@@ -4,6 +4,7 @@ use log::{error, trace};
 use std::alloc::System;
 use std::ffi::OsString;
 use std::future::Future;
+use tokio::runtime;
 use tokio::runtime::Runtime;
 use uka_util::ptr::{OwnedPtr, RawPtr};
 
@@ -230,7 +231,10 @@ where
     fn from(value: Shiori<C, S>) -> Self {
         Adapter {
             shiori: value,
-            runtime: Runtime::new().expect("failed to create tokio runtime"),
+            runtime: runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("failed to create tokio runtime"),
         }
     }
 }
@@ -244,7 +248,10 @@ where
         let shiori = Shiori::from(value);
         Adapter {
             shiori,
-            runtime: Runtime::new().expect("failed to create tokio runtime"),
+            runtime: runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("failed to create tokio runtime"),
         }
     }
 }


### PR DESCRIPTION
```
Caused by:
  process didn't exit successfully: `D:\a\uka-rs\uka-rs\target\debug\deps\uka_shiori-fa3b63381d2ed208.exe` (exit code: 0xc0000005, STATUS_ACCESS_VIOLATION)
Error: Process completed with exit code 1.
```

`STATUS_ACCESS_VIOLATION` occurs when running a unit test that calls a DLL on `x86_64-pc-windows-msvc`.
The cause is unknown but can be avoided by building Runtime with `new_current_thread` instead of `new_multi_thread`.

