### PR TITLE
refactor rename as_bytes to to_vec in Request/Response type

### DIFF
--- a/uka_shiori/src/dll/adapter.rs
+++ b/uka_shiori/src/dll/adapter.rs
@@ -210,7 +210,7 @@ where
             }
         };
 
-        let bytes = resp.as_bytes();
+        let bytes = resp.to_vec();
         len.as_mut_ptr().write(bytes.len());
         let h = OwnedPtr::from_vec(bytes).into_raw_slice().as_ptr() as isize;
 
@@ -385,7 +385,7 @@ mod tests {
             .version(v3::Version::SHIORI_30)
             .build()
             .expect("failed to build request");
-        let bytes = ManuallyDrop::new(req.as_bytes());
+        let bytes = ManuallyDrop::new(req.to_vec());
         let len = bytes.len();
         let h =
             unsafe { adapter.request(bytes.as_ptr() as isize, &len as *const usize as *mut usize) };

--- a/uka_shiori/src/dll/caller.rs
+++ b/uka_shiori/src/dll/caller.rs
@@ -158,7 +158,7 @@ impl Caller<v3::Request> for ShioriCaller {
     unsafe fn call(&self, request: v3::Request) -> v3::Response {
         use v3::IntoResponse;
 
-        let bytes = request.as_bytes();
+        let bytes = request.to_vec();
         let len = bytes.len();
         let h = OwnedPtr::from_vec(bytes).into_raw_slice().as_ptr() as isize;
 

--- a/uka_shiori/src/types/v3/request.rs
+++ b/uka_shiori/src/types/v3/request.rs
@@ -155,7 +155,7 @@ impl Request {
     }
 
     /// Convert request to bytes.
-    pub fn as_bytes(&self) -> Vec<u8> {
+    pub fn to_vec(&self) -> Vec<u8> {
         let mut buf = Vec::new();
         buf.extend_from_slice(self.method.to_string().as_bytes());
         buf.extend_from_slice(b" ");
@@ -391,11 +391,11 @@ mod tests {
         assert_eq!(request1.security_level(), request2.security_level());
 
         assert_eq!(
-            request1.as_bytes(),
-            request2.as_bytes(),
+            request1.to_vec(),
+            request2.to_vec(),
             "\nassertion failed: `(left == right)\n  left: `{:?}`,\n right: `{:?}`",
-            String::from_utf8_lossy(&request1.as_bytes()),
-            String::from_utf8_lossy(&request2.as_bytes())
+            String::from_utf8_lossy(&request1.to_vec()),
+            String::from_utf8_lossy(&request2.to_vec())
         );
 
         Ok(())

--- a/uka_shiori/src/types/v3/response.rs
+++ b/uka_shiori/src/types/v3/response.rs
@@ -142,7 +142,7 @@ impl Response {
         self.headers.get(&HeaderName::VALUE)
     }
 
-    pub fn as_bytes(&self) -> Vec<u8> {
+    pub fn to_vec(&self) -> Vec<u8> {
         let mut buf = Vec::new();
         buf.extend_from_slice(self.version.to_string().as_bytes());
         buf.extend_from_slice(b" ");
@@ -313,11 +313,11 @@ mod tests {
         assert_eq!(response1.sender(), response2.sender());
         assert_eq!(response1.value(), response2.value());
         assert_eq!(
-            response1.as_bytes(),
-            response2.as_bytes(),
+            response1.to_vec(),
+            response2.to_vec(),
             "\nassertion failed: `(left == right)\n  left: `{:?}`,\n right: `{:?}`",
-            String::from_utf8_lossy(&response1.as_bytes()),
-            String::from_utf8_lossy(&response2.as_bytes())
+            String::from_utf8_lossy(&response1.to_vec()),
+            String::from_utf8_lossy(&response2.to_vec())
         );
 
         Ok(())

--- a/uka_shiori/tests/spec_shiori_v3.rs
+++ b/uka_shiori/tests/spec_shiori_v3.rs
@@ -41,10 +41,10 @@ fn spec_shiori_request() -> anyhow::Result<()> {
     );
 
     assert_eq!(
-        request.as_bytes(),
+        request.to_vec(),
         input,
         "\nassertion failed: `(left == right)\n  left: `{:?}`,\n right: `{:?}`",
-        String::from_utf8_lossy(&request.as_bytes()),
+        String::from_utf8_lossy(&request.to_vec()),
         String::from_utf8_lossy(&input)
     );
 
@@ -85,10 +85,10 @@ fn spec_shiori_response() -> anyhow::Result<()> {
     );
 
     assert_eq!(
-        response.as_bytes(),
+        response.to_vec(),
         input,
         "\nassertion failed: `(left == right)\n  left: `{:?}`,\n right: `{:?}`",
-        String::from_utf8_lossy(&response.as_bytes()),
+        String::from_utf8_lossy(&response.to_vec()),
         String::from_utf8_lossy(&input)
     );
 
@@ -127,10 +127,10 @@ fn spec_shiori_response_with_name_of_person_to_talk_to() -> anyhow::Result<()> {
     );
 
     assert_eq!(
-        response.as_bytes(),
+        response.to_vec(),
         input,
         "\nassertion failed: `(left == right)\n  left: `{:?}`,\n right: `{:?}`",
-        String::from_utf8_lossy(&response.as_bytes()),
+        String::from_utf8_lossy(&response.to_vec()),
         String::from_utf8_lossy(&input)
     );
 

--- a/uka_sstp/src/request.rs
+++ b/uka_sstp/src/request.rs
@@ -204,7 +204,7 @@ impl Request {
     }
 
     /// Convert request to bytes.
-    pub fn as_bytes(&self) -> Vec<u8> {
+    pub fn to_vec(&self) -> Vec<u8> {
         let mut buf = Vec::new();
         buf.extend_from_slice(self.method.to_string().as_bytes());
         buf.extend_from_slice(b" ");

--- a/uka_sstp/src/response.rs
+++ b/uka_sstp/src/response.rs
@@ -214,7 +214,7 @@ impl Response {
     }
 
     /// Convert request to bytes.
-    pub fn as_bytes(&self) -> Vec<u8> {
+    pub fn to_vec(&self) -> Vec<u8> {
         let mut buf = Vec::new();
         buf.extend_from_slice(self.version.to_string().as_bytes());
         buf.extend_from_slice(b" ");

--- a/uka_sstp/tests/example_spec.rs
+++ b/uka_sstp/tests/example_spec.rs
@@ -27,7 +27,7 @@ fn example_notify1_0() -> Result<()> {
         .header(HeaderName::REFERENCE1, "筋肉少女帯")
         .charset(Charset::SHIFT_JIS)
         .build()?;
-    let input = request.as_bytes();
+    let input = request.to_vec();
 
     let request = Request::parse(&input)?;
     assert_eq!(request.method(), Method::NOTIFY);
@@ -62,7 +62,7 @@ fn example_notify1_0() -> Result<()> {
     assert!(request.reference7().is_none());
     assert_eq!(request.charset(), Charset::SHIFT_JIS);
 
-    assert_eq!(request.as_bytes(), input);
+    assert_eq!(request.to_vec(), input);
 
     Ok(())
 }
@@ -103,7 +103,7 @@ fn example_notify1_1() -> Result<()> {
         )
         .charset(Charset::SHIFT_JIS)
         .build()?;
-    let input = request.as_bytes();
+    let input = request.to_vec();
 
     let request = Request::parse(&input)?;
     assert_eq!(request.method(), Method::NOTIFY);
@@ -159,7 +159,7 @@ fn example_notify1_1() -> Result<()> {
     );
     assert_eq!(request.charset(), Charset::SHIFT_JIS);
 
-    assert_eq!(request.as_bytes(), input);
+    assert_eq!(request.to_vec(), input);
 
     Ok(())
 }
@@ -184,7 +184,7 @@ fn example_send_1_1() -> Result<()> {
         .header(HeaderName::OPTION, "nodescript,notranslate")
         .charset(Charset::SHIFT_JIS)
         .build()?;
-    let input = request.as_bytes();
+    let input = request.to_vec();
 
     let request = Request::parse(&input)?;
     assert_eq!(request.method(), Method::SEND);
@@ -209,7 +209,7 @@ fn example_send_1_1() -> Result<()> {
     );
     assert_eq!(request.charset(), Charset::SHIFT_JIS);
 
-    assert_eq!(request.as_bytes(), input);
+    assert_eq!(request.to_vec(), input);
 
     Ok(())
 }
@@ -239,7 +239,7 @@ fn example_send_1_2() -> Result<()> {
         .header(HeaderName::ENTRY, "#temp1,\\h\\s0酒に逃げるなヨ！\\e")
         .charset(Charset::SHIFT_JIS)
         .build()?;
-    let input = request.as_bytes();
+    let input = request.to_vec();
 
     let request = Request::parse(&input)?;
     assert_eq!(request.method(), Method::SEND);
@@ -271,7 +271,7 @@ fn example_send_1_2() -> Result<()> {
     );
     assert_eq!(request.charset(), Charset::SHIFT_JIS);
 
-    assert_eq!(request.as_bytes(), input);
+    assert_eq!(request.to_vec(), input);
 
     Ok(())
 }
@@ -309,7 +309,7 @@ fn example_send_1_3() -> Result<()> {
         )
         .charset(Charset::SHIFT_JIS)
         .build()?;
-    let input = request.as_bytes();
+    let input = request.to_vec();
 
     let request = Request::parse(&input)?;
     assert_eq!(request.method(), Method::SEND);
@@ -345,7 +345,7 @@ fn example_send_1_3() -> Result<()> {
     );
     assert_eq!(request.charset(), Charset::SHIFT_JIS);
 
-    assert_eq!(request.as_bytes(), input);
+    assert_eq!(request.to_vec(), input);
 
     Ok(())
 }
@@ -392,7 +392,7 @@ fn example_send_1_4() -> Result<()> {
         )
         .charset(Charset::SHIFT_JIS)
         .build()?;
-    let input = request.as_bytes();
+    let input = request.to_vec();
 
     let request = Request::parse(&input)?;
     assert_eq!(request.method(), Method::SEND);
@@ -433,7 +433,7 @@ fn example_send_1_4() -> Result<()> {
     );
     assert_eq!(request.charset(), Charset::SHIFT_JIS);
 
-    assert_eq!(request.as_bytes(), input);
+    assert_eq!(request.to_vec(), input);
 
     Ok(())
 }
@@ -456,7 +456,7 @@ fn example_execute_1_0() -> Result<()> {
         .header(HeaderName::COMMAND, "GetName")
         .charset(Charset::SHIFT_JIS)
         .build()?;
-    let input = request.as_bytes();
+    let input = request.to_vec();
 
     let request = Request::parse(&input)?;
     assert_eq!(request.method(), Method::EXECUTE);
@@ -473,7 +473,7 @@ fn example_execute_1_0() -> Result<()> {
     );
     assert_eq!(request.charset(), Charset::SHIFT_JIS);
 
-    assert_eq!(request.as_bytes(), input);
+    assert_eq!(request.to_vec(), input);
 
     Ok(())
 }
@@ -503,7 +503,7 @@ fn example_execute_1_1() -> Result<()> {
         .header(HeaderName::COMMAND, "SetCookie[visitcount,1]")
         .charset(Charset::SHIFT_JIS)
         .build()?;
-    let input = request.as_bytes();
+    let input = request.to_vec();
 
     let request = Request::parse(&input)?;
     assert_eq!(request.method(), Method::EXECUTE);
@@ -520,7 +520,7 @@ fn example_execute_1_1() -> Result<()> {
     );
     assert_eq!(request.charset(), Charset::SHIFT_JIS);
 
-    assert_eq!(request.as_bytes(), input);
+    assert_eq!(request.to_vec(), input);
 
     let request = Request::builder()
         .execute(Version::SSTP_11)
@@ -528,7 +528,7 @@ fn example_execute_1_1() -> Result<()> {
         .header(HeaderName::COMMAND, "GetCookie[visitcount]")
         .charset(Charset::SHIFT_JIS)
         .build()?;
-    let input = request.as_bytes();
+    let input = request.to_vec();
 
     let request = Request::parse(&input)?;
     assert_eq!(request.method(), Method::EXECUTE);
@@ -545,7 +545,7 @@ fn example_execute_1_1() -> Result<()> {
     );
     assert_eq!(request.charset(), Charset::SHIFT_JIS);
 
-    assert_eq!(request.as_bytes(), input);
+    assert_eq!(request.to_vec(), input);
 
     Ok(())
 }
@@ -568,7 +568,7 @@ fn example_execute_1_2() -> Result<()> {
         .header(HeaderName::COMMAND, "GetVersion")
         .charset(Charset::SHIFT_JIS)
         .build()?;
-    let input = request.as_bytes();
+    let input = request.to_vec();
 
     let request = Request::parse(&input)?;
     assert_eq!(request.method(), Method::EXECUTE);
@@ -585,7 +585,7 @@ fn example_execute_1_2() -> Result<()> {
     );
     assert_eq!(request.charset(), Charset::SHIFT_JIS);
 
-    assert_eq!(request.as_bytes(), input);
+    assert_eq!(request.to_vec(), input);
 
     Ok(())
 }
@@ -608,7 +608,7 @@ fn example_execute_1_3() -> Result<()> {
         .header(HeaderName::COMMAND, "Quiet")
         .charset(Charset::SHIFT_JIS)
         .build()?;
-    let input = request.as_bytes();
+    let input = request.to_vec();
 
     let request = Request::parse(&input)?;
     assert_eq!(request.method(), Method::EXECUTE);
@@ -625,7 +625,7 @@ fn example_execute_1_3() -> Result<()> {
     );
     assert_eq!(request.charset(), Charset::SHIFT_JIS);
 
-    assert_eq!(request.as_bytes(), input);
+    assert_eq!(request.to_vec(), input);
 
     Ok(())
 }
@@ -648,7 +648,7 @@ fn example_give_1_1() -> Result<()> {
         .header(HeaderName::DOCUMENT, "こんにちはさくらです。闇の力を秘めし鍵よ真の姿を我の前に示せレリーズ。汝のあるべき姿に戻れクロウカード。")
         .charset(Charset::SHIFT_JIS)
         .build()?;
-    let input = request.as_bytes();
+    let input = request.to_vec();
 
     let request = Request::parse(&input)?;
     assert_eq!(request.method(), Method::GIVE);
@@ -666,7 +666,7 @@ fn example_give_1_1() -> Result<()> {
         Some("こんにちはさくらです。闇の力を秘めし鍵よ真の姿を我の前に示せレリーズ。汝のあるべき姿に戻れクロウカード。".to_string()));
     assert_eq!(request.charset(), Charset::SHIFT_JIS);
 
-    assert_eq!(request.as_bytes(), input);
+    assert_eq!(request.to_vec(), input);
 
     Ok(())
 }
@@ -691,7 +691,7 @@ fn example_communicate_1_1() -> Result<()> {
         .header(HeaderName::OPTION, "substitute")
         .charset(Charset::SHIFT_JIS)
         .build()?;
-    let input = request.as_bytes();
+    let input = request.to_vec();
 
     let request = Request::parse(&input)?;
     assert_eq!(request.method(), Method::COMMUNICATE);
@@ -716,7 +716,7 @@ fn example_communicate_1_1() -> Result<()> {
     );
     assert_eq!(request.charset(), Charset::SHIFT_JIS);
 
-    assert_eq!(request.as_bytes(), input);
+    assert_eq!(request.to_vec(), input);
 
     Ok(())
 }
@@ -745,7 +745,7 @@ fn example_communicate_1_2() -> Result<()> {
         .header(HeaderName::REFERENCE0, "N/A")
         .charset(Charset::SHIFT_JIS)
         .build()?;
-    let input = request.as_bytes();
+    let input = request.to_vec();
 
     let request = Request::parse(&input)?;
     assert_eq!(request.method(), Method::COMMUNICATE);
@@ -776,7 +776,7 @@ fn example_communicate_1_2() -> Result<()> {
     );
     assert_eq!(request.charset(), Charset::SHIFT_JIS);
 
-    assert_eq!(request.as_bytes(), input);
+    assert_eq!(request.to_vec(), input);
 
     Ok(())
 }
@@ -803,7 +803,7 @@ fn example_response_no_additional() -> Result<()> {
             "\\h\\s0テストー。\\u\\s[10]テストやな。",
         )
         .build()?;
-    let input = response.as_bytes();
+    let input = response.to_vec();
 
     let response = Response::parse(&input)?;
     assert_eq!(response.version(), Version::SSTP_14);
@@ -819,7 +819,7 @@ fn example_response_no_additional() -> Result<()> {
     matches!(response.additional(), AdditionalData::Empty);
     assert_eq!(response.additional().text()?, "");
 
-    assert_eq!(response.as_bytes(), input);
+    assert_eq!(response.to_vec(), input);
 
     Ok(())
 }
@@ -847,7 +847,7 @@ fn example_response_use_additional() -> Result<()> {
         )
         .additional("追加データはここ")
         .build()?;
-    let input = response.as_bytes();
+    let input = response.to_vec();
 
     let response = Response::parse(&input)?;
     assert_eq!(response.version(), Version::SSTP_14);
@@ -867,7 +867,7 @@ fn example_response_use_additional() -> Result<()> {
         "追加データはここ"
     );
 
-    assert_eq!(response.as_bytes(), input);
+    assert_eq!(response.to_vec(), input);
 
     Ok(())
 }

--- a/uka_sstp/tests/extend_spec.rs
+++ b/uka_sstp/tests/extend_spec.rs
@@ -20,7 +20,7 @@ fn spec_duplicate_single_headers_can_get_the_first_header() -> Result<()> {
         .charset(Charset::UTF8)
         .charset(Charset::SHIFT_JIS)
         .build()?;
-    let input = request.as_bytes();
+    let input = request.to_vec();
 
     assert_eq!(
         String::from_utf8(input.clone())?
@@ -138,7 +138,7 @@ fn spec_character_set_for_request_header_names_is_based_on_rfc_7230() -> Result<
         .header(HeaderName::from_static(name)?, "foo")
         .charset(Charset::SHIFT_JIS)
         .build()?;
-    let input = request.as_bytes();
+    let input = request.to_vec();
 
     let request = Request::parse(&input)?;
     assert_eq!(
@@ -167,7 +167,7 @@ fn spec_character_set_for_response_header_names_is_based_on_rfc_7230() -> Result
         .header(HeaderName::from_static(name)?, "foo")
         .charset(Charset::SHIFT_JIS)
         .build()?;
-    let input = request.as_bytes();
+    let input = request.to_vec();
 
     let request = Request::parse(&input)?;
     assert_eq!(


### PR DESCRIPTION
```
fn as_bytes(&self) -> Vec<u8>
```

If it is `as_bytes`, the return value should be `&[u8]`, but since what is actually returned is `Vec<u8>`, it is renamed to conform to Rust's naming convention.