### PR TITLE
Refactor to use RFC7230 compliant strings

### DIFF
--- a/uka_shiori/Cargo.toml
+++ b/uka_shiori/Cargo.toml
@@ -15,4 +15,4 @@ uka_util = { path = "../uka_util" }
 [dev-dependencies]
 anyhow = "1.0.71"
 once_cell = "1.18.0"
-rstest = "0.18.2"
+rstest = "0.18.1"

--- a/uka_shiori/src/types/v3/request.rs
+++ b/uka_shiori/src/types/v3/request.rs
@@ -162,7 +162,7 @@ impl Request {
         buf.extend_from_slice(self.version.to_string().as_bytes());
         buf.extend_from_slice(b"\r\n");
         for (name, value) in self.headers.iter() {
-            buf.extend_from_slice(&name.as_bytes());
+            buf.extend_from_slice(&name.to_vec());
             buf.extend_from_slice(b": ");
             buf.extend_from_slice(&value.as_bytes());
             buf.extend_from_slice(b"\r\n");

--- a/uka_shiori/src/types/v3/response.rs
+++ b/uka_shiori/src/types/v3/response.rs
@@ -149,7 +149,7 @@ impl Response {
         buf.extend_from_slice(self.status_code.to_string().as_bytes());
         buf.extend_from_slice(b"\r\n");
         for (name, value) in self.headers.iter() {
-            buf.extend_from_slice(&name.as_bytes());
+            buf.extend_from_slice(&name.to_vec());
             buf.extend_from_slice(b": ");
             buf.extend_from_slice(&value.as_bytes());
             buf.extend_from_slice(b"\r\n");

--- a/uka_sstp/Cargo.toml
+++ b/uka_sstp/Cargo.toml
@@ -11,4 +11,4 @@ uka_util = { path = "../uka_util" }
 
 [dev-dependencies]
 anyhow = "1.0.72"
-rstest = "0.18.2"
+rstest = "0.18.1"

--- a/uka_sstp/src/request.rs
+++ b/uka_sstp/src/request.rs
@@ -211,7 +211,7 @@ impl Request {
         buf.extend_from_slice(self.version.to_string().as_bytes());
         buf.extend_from_slice(b"\r\n");
         for (name, value) in self.headers.iter() {
-            buf.extend_from_slice(&name.as_bytes());
+            buf.extend_from_slice(&name.to_vec());
             buf.extend_from_slice(b": ");
             buf.extend_from_slice(&value.as_bytes());
             buf.extend_from_slice(b"\r\n");

--- a/uka_sstp/src/response.rs
+++ b/uka_sstp/src/response.rs
@@ -221,7 +221,7 @@ impl Response {
         buf.extend_from_slice(self.status_code.to_string().as_bytes());
         buf.extend_from_slice(b"\r\n");
         for (name, value) in self.headers.iter() {
-            buf.extend_from_slice(&name.as_bytes());
+            buf.extend_from_slice(&name.to_vec());
             buf.extend_from_slice(b": ");
             buf.extend_from_slice(&value.as_bytes());
             buf.extend_from_slice(b"\r\n");

--- a/uka_util/Cargo.toml
+++ b/uka_util/Cargo.toml
@@ -14,4 +14,6 @@ libc = "0.2.147"
 windows = { version = "0.48.0", features = ["Win32_System_Memory", "Win32_Foundation"] }
 
 [dev-dependencies]
+anyhow = "1.0.72"
+rstest = "0.18.1"
 

--- a/uka_util/src/lib.rs
+++ b/uka_util/src/lib.rs
@@ -4,4 +4,6 @@ pub mod cursor;
 pub mod decode;
 pub mod encode;
 pub mod ptr;
+pub mod string;
+
 pub use uka_macro;

--- a/uka_util/src/string.rs
+++ b/uka_util/src/string.rs
@@ -1,0 +1,216 @@
+use std::fmt::Display;
+use std::ops::Deref;
+
+/// Errors that may occur during conversion.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("invalid character: `{0}`")]
+    InvalidCharacter(u8),
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+/// Rfc7230String is a string that conforms to the character set defined in RFC 7230.
+/// Alpa-numeric characters, some symbols are allowed.
+///
+/// See: https://triple-underscore.github.io/RFC7230-ja.html#section-3.2.6
+///
+/// # Examples
+///
+/// ```rust
+/// # use uka_util::string::Rfc7230String;
+/// #
+/// let name = Rfc7230String::from_string("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&'*+-.^_`|~".to_string());
+/// assert!(name.is_ok());
+/// assert_eq!(name.unwrap().to_string(), "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&'*+-.^_`|~");
+/// ```
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct Rfc7230String(String);
+
+impl Rfc7230String {
+    /// Create a new Rfc7230String.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use uka_util::string::Rfc7230String;
+    /// #
+    /// let name = Rfc7230String::new();
+    /// assert_eq!(name.to_string(), "");
+    /// ```
+    pub fn new() -> Self {
+        Self(String::new())
+    }
+
+    /// Create a new Rfc7230String from a bytes.
+    ///
+    /// # Errors
+    ///
+    /// If the bytes contains invalid characters, an error will be returned.
+    ///　Valid characters are as follows:
+    /// - Lowercase letters: `abcdefghijklmnopqrstuvwxyz`
+    /// - Uppercase letters: `ABCDEFGHIJKLMNOPQRSTUVWXYZ`
+    /// - Numbers: `0123456789`
+    /// - Symbols: `!#$%&'*+-.^_`|~`
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use uka_util::string::Rfc7230String;
+    /// #
+    /// let name = Rfc7230String::from_utf8(b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&'*+-.^_`|~".to_vec());
+    ///  assert!(name.is_ok());
+    /// assert_eq!(name.unwrap().to_string(), "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&'*+-.^_`|~");
+    /// ```
+    pub fn from_utf8(bytes: Vec<u8>) -> Result<Self> {
+        let opt = bytes.iter().find(|byte| !matches!(*byte, b'0'..=b'9' | b'!' | b'#'..=b'\'' | b'*'..=b'+' | b'-'..=b'.' | b'^'..=b'`' | b'A'..=b'Z' | b'a'..=b'z' | b'|' | b'~'));
+        if let Some(c) = opt {
+            Err(Error::InvalidCharacter(c.clone()))
+        } else {
+            Ok(Self(
+                String::from_utf8(bytes).expect("unreachable: within the range of UTF-8"),
+            ))
+        }
+    }
+
+    /// Create a new Rfc7230String from a string.
+    /// This function is equivalent to `Rfc7230String::from_utf8(s.into_bytes())`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use uka_util::string::Rfc7230String;
+    /// #
+    /// let name = Rfc7230String::from_string("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&'*+-.^_`|~".to_string());
+    /// assert!(name.is_ok());
+    /// assert_eq!(name.unwrap().to_string(), "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&'*+-.^_`|~");
+    /// ```
+    pub fn from_string(s: String) -> Result<Self> {
+        Self::from_utf8(s.into_bytes())
+    }
+}
+
+impl Deref for Rfc7230String {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Display for Rfc7230String {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+    use rstest::rstest;
+
+    #[test]
+    fn test_from_utf8_pass_alpha() -> Result<()> {
+        let name = Rfc7230String::from_utf8(
+            b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".to_vec(),
+        )?;
+        assert_eq!(
+            name.as_str(),
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_utf8_pass_digit() -> Result<()> {
+        let name = Rfc7230String::from_utf8(b"1234567890".to_vec())?;
+        assert_eq!(name.as_str(), "1234567890");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_utf8_pass_acceptable_symbol() -> Result<()> {
+        let name = Rfc7230String::from_utf8(b"!#$%&'*+-.^_`|~".to_vec())?;
+        assert_eq!(name.as_str(), "!#$%&'*+-.^_`|~");
+
+        Ok(())
+    }
+
+    #[rstest]
+    #[case::nul("\0")]
+    #[case::soh("\x01")]
+    #[case::stx("\x02")]
+    #[case::etx("\x03")]
+    #[case::eot("\x04")]
+    #[case::enq("\x05")]
+    #[case::ack("\x06")]
+    #[case::bel("\x07")]
+    #[case::bs("\x08")]
+    #[case::ht("\x09")]
+    #[case::lf("\n")]
+    #[case::vt("\x0b")]
+    #[case::ff("\x0c")]
+    #[case::cr("\r")]
+    #[case::so("\x0e")]
+    #[case::si("\x0f")]
+    #[case::dle("\x10")]
+    #[case::dc1("\x11")]
+    #[case::dc2("\x12")]
+    #[case::dc3("\x13")]
+    #[case::dc4("\x14")]
+    #[case::nak("\x15")]
+    #[case::syn("\x16")]
+    #[case::etb("\x17")]
+    #[case::can("\x18")]
+    #[case::em("\x19")]
+    #[case::sub("\x1a")]
+    #[case::esc("\x1b")]
+    #[case::fs("\x1c")]
+    #[case::gs("\x1d")]
+    #[case::rs("\x1e")]
+    #[case::us("\x1f")]
+    #[case::delete("\x7f")]
+    fn test_from_utf8_failed_control_character(#[case] input: String) -> Result<()> {
+        let res = Rfc7230String::from_utf8(input.into_bytes());
+        assert!(res.is_err());
+        matches!(res, Err(Error::InvalidCharacter(_)));
+
+        Ok(())
+    }
+
+    #[rstest]
+    #[case::left_parenthesis("(")]
+    #[case::right_parenthesis(")")]
+    #[case::comma(",")]
+    #[case::slash("/")]
+    #[case::semicolon(";")]
+    #[case::less_than_sign("<")]
+    #[case::equals_sign("=")]
+    #[case::greater_than_sign(">")]
+    #[case::question_mark("?")]
+    #[case::at_sign("@")]
+    #[case::left_square_bracket("[")]
+    #[case::backslash("\\")]
+    #[case::right_square_bracket("]")]
+    #[case::left_curly_brace("{")]
+    #[case::right_curly_brace("}")]
+    fn test_from_utf8_failed_unavailable_symbols(#[case] input: String) -> Result<()> {
+        let res = Rfc7230String::from_utf8(input.into_bytes());
+        assert!(res.is_err());
+        matches!(res, Err(Error::InvalidCharacter(_)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_utf8_failed_out_of_ascii_range() -> Result<()> {
+        let res = Rfc7230String::from_utf8(b"\x80".to_vec());
+        assert!(res.is_err());
+        matches!(res, Err(Error::InvalidCharacter(_)));
+
+        Ok(())
+    }
+}

--- a/uka_util/src/string.rs
+++ b/uka_util/src/string.rs
@@ -65,7 +65,7 @@ impl Rfc7230String {
     pub fn from_utf8(bytes: Vec<u8>) -> Result<Self> {
         let opt = bytes.iter().find(|byte| !matches!(*byte, b'0'..=b'9' | b'!' | b'#'..=b'\'' | b'*'..=b'+' | b'-'..=b'.' | b'^'..=b'`' | b'A'..=b'Z' | b'a'..=b'z' | b'|' | b'~'));
         if let Some(c) = opt {
-            Err(Error::InvalidCharacter(c.clone()))
+            Err(Error::InvalidCharacter(*c))
         } else {
             Ok(Self(
                 String::from_utf8(bytes).expect("unreachable: within the range of UTF-8"),
@@ -95,6 +95,12 @@ impl Deref for Rfc7230String {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl Default for Rfc7230String {
+    fn default() -> Self {
+        Self::new()
     }
 }
 


### PR DESCRIPTION
PR Type:
**Refactoring**

___
PR Description:
**This PR refactors the code to use RFC7230 compliant strings. It introduces a new utility module for handling these strings and updates the existing code to use this new functionality. The PR also includes updates to the tests to reflect these changes.**

___
PR Main Files Walkthrough:
-`uka_util/src/string.rs`: This is a new file that defines a new `Rfc7230String` struct and related functionality for handling RFC7230 compliant strings.
-`uka_sstp/src/header/name.rs` and `uka_shiori/src/types/v3/header/name.rs`: These files have been updated to use the new `Rfc7230String` struct instead of regular strings.
-`uka_sstp/src/response.rs`, `uka_shiori/src/types/v3/response.rs`, `uka_shiori/src/types/v3/request.rs`, and `uka_sstp/src/request.rs`: These files have been updated to use the new `Rfc7230String` struct in their header handling code.
-`uka_util/Cargo.toml`, `uka_shiori/Cargo.toml`, and `uka_sstp/Cargo.toml`: These files have been updated to include the new `string` module and update the version of the `rstest` dependency.
