### PR TITLE
Fix CI issues: update workspace resolver to v2 and fix lifetime syntax

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "examples/ghost",
     "uka_macro",

--- a/uka_shiori/src/dll/adapter.rs
+++ b/uka_shiori/src/dll/adapter.rs
@@ -259,6 +259,7 @@ where
 trait BytesExt {
     type Type;
     fn from_bytes(bytes: &[Self::Type]) -> Self;
+    #[allow(dead_code)]
     fn to_vec(&self) -> Vec<Self::Type>;
 }
 

--- a/uka_shiori/src/dll/caller.rs
+++ b/uka_shiori/src/dll/caller.rs
@@ -28,6 +28,7 @@ type UnloadFunc = unsafe extern "C" fn() -> bool;
 /// extern "C" __declspec(dllexport) HGLOBAL __cdecl request(HGLOBAL h, long *len);
 /// function request(h: hglobal; var len: longint): hglobal; cdecl; export;
 /// ```
+#[allow(dead_code)]
 type RequestFunc = unsafe extern "C" fn(h: isize, len: *mut usize) -> isize;
 
 /// Library wraps the SHIORI DLL so that Rust can call load/unload/request.
@@ -77,6 +78,7 @@ impl Library {
     }
 
     /// Call SHIORI DLL request.
+    #[allow(dead_code)]
     pub fn request(&self, h: isize, len: *mut usize) -> isize {
         unsafe {
             let func = self
@@ -105,6 +107,7 @@ pub enum Error {
 }
 
 /// Caller is the interface for calling the SHIORI DLL.
+#[allow(dead_code)]
 trait Caller<R> {
     /// Response that is a pair of `R` of Request
     type Response;

--- a/uka_shiori/src/types/v3/parse.rs
+++ b/uka_shiori/src/types/v3/parse.rs
@@ -41,13 +41,13 @@ pub fn parse_request(input: &[u8]) -> Result<Request> {
     let headers = parse_headers(&mut cursor)?;
     let charset = headers
         .get(&HeaderName::CHARSET)
-        .ok_or_else(|| Error::MissingHeader(HeaderName::CHARSET))
+        .ok_or(Error::MissingHeader(HeaderName::CHARSET))
         .and_then(|v| {
             v.text()
                 .map_err(|e| Error::FailedDecode(HeaderName::CHARSET, e))
         })
         .and_then(|v| Charset::from_string(v).map_err(Error::from))
-        .or_else(|_| Ok::<Charset, ParseError>(Charset::ASCII))?;
+        .or(Ok::<Charset, ParseError>(Charset::ASCII))?;
     skip_newline(&mut cursor)?;
     eof(&mut cursor)?;
 
@@ -68,13 +68,13 @@ pub fn parse_response(input: &[u8]) -> Result<Response> {
     let headers = parse_headers(&mut cursor)?;
     let charset = headers
         .get(&HeaderName::CHARSET)
-        .ok_or_else(|| Error::MissingHeader(HeaderName::CHARSET))
+        .ok_or(Error::MissingHeader(HeaderName::CHARSET))
         .and_then(|v| {
             v.text()
                 .map_err(|e| Error::FailedDecode(HeaderName::CHARSET, e))
         })
         .and_then(|v| Charset::from_string(v).map_err(Error::from))
-        .or_else(|_| Ok::<Charset, ParseError>(Charset::ASCII))?;
+        .or(Ok::<Charset, ParseError>(Charset::ASCII))?;
     skip_newline(&mut cursor)?;
     eof(&mut cursor)?;
 

--- a/uka_sstp/src/parse.rs
+++ b/uka_sstp/src/parse.rs
@@ -64,7 +64,7 @@ pub fn parse_request(input: &[u8]) -> Result<Request> {
     let headers = parse_headers(&mut cursor)?;
     let charset = headers
         .get(&HeaderName::CHARSET)
-        .ok_or_else(|| Error::MissingHeader(HeaderName::CHARSET))
+        .ok_or(Error::MissingHeader(HeaderName::CHARSET))
         .and_then(|v| {
             v.text()
                 .map_err(|e| Error::FailedDecode(HeaderName::CHARSET, e))
@@ -91,7 +91,7 @@ pub fn parse_response(input: &[u8]) -> Result<Response> {
     let headers = parse_headers(&mut cursor)?;
     let charset = headers
         .get(&HeaderName::CHARSET)
-        .ok_or_else(|| Error::MissingHeader(HeaderName::CHARSET))
+        .ok_or(Error::MissingHeader(HeaderName::CHARSET))
         .and_then(|v| {
             v.text()
                 .map_err(|e| Error::FailedDecode(HeaderName::CHARSET, e))

--- a/uka_util/src/bag.rs
+++ b/uka_util/src/bag.rs
@@ -146,7 +146,7 @@ impl<K: Eq + Hash, V> OrderedBag<K, V> {
     /// assert_eq!(iter.next(), Some(&("key2", "value2")));
     /// assert!(iter.next().is_none());
     /// ```
-    pub fn iter(&self) -> std::slice::Iter<(K, V)> {
+    pub fn iter(&self) -> std::slice::Iter<'_, (K, V)> {
         self.entries.iter()
     }
 }

--- a/uka_util/src/bag.rs
+++ b/uka_util/src/bag.rs
@@ -63,10 +63,10 @@ impl<K: Eq + Hash, V> OrderedBag<K, V> {
     /// bag.insert("key1", "value1");
     /// assert_eq!(bag.get("key1"), Some(&"value1"));
     /// ```
-    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
+    pub fn get<Q>(&self, k: &Q) -> Option<&V>
     where
+        Q: ?Sized + Eq + Hash,
         K: Borrow<Q>,
-        Q: Eq + Hash,
     {
         self.map
             .get(k)
@@ -87,10 +87,10 @@ impl<K: Eq + Hash, V> OrderedBag<K, V> {
     ///
     /// assert_eq!(bag.get_all("key1"), [&"value1", &"value2"].to_vec());
     /// ```
-    pub fn get_all<Q: ?Sized>(&self, k: &Q) -> Vec<&V>
+    pub fn get_all<Q>(&self, k: &Q) -> Vec<&V>
     where
+        Q: ?Sized + Eq + Hash,
         K: Borrow<Q>,
-        Q: Eq + Hash,
     {
         self.map
             .get(k)


### PR DESCRIPTION
This pull request includes a set of small improvements and code cleanups across several crates, focusing on minor API adjustments, code style consistency, and suppressing warnings for unused code. The most notable changes are grouped below.

### API and Type Improvements

* Updated the generic bounds for the `get` and `get_all` methods in `OrderedBag` to improve flexibility and type inference, and specified the lifetime for the `iter` method's return type in `uka_util/src/bag.rs`. [[1]](diffhunk://#diff-146e4c47bc29a9e8efb1b8fdc3c062a741fbf6fbccaeb3375316242f5f15880dL66-L69) [[2]](diffhunk://#diff-146e4c47bc29a9e8efb1b8fdc3c062a741fbf6fbccaeb3375316242f5f15880dL90-L93) [[3]](diffhunk://#diff-146e4c47bc29a9e8efb1b8fdc3c062a741fbf6fbccaeb3375316242f5f15880dL149-R149)

### Error Handling and Code Style

* Simplified error handling in charset extraction by replacing `ok_or_else` with `ok_or` and by using `.or(...)` instead of `.or_else(...)` in both SHIORI and SSTP request/response parsers (`uka_shiori/src/types/v3/parse.rs`, `uka_sstp/src/parse.rs`). [[1]](diffhunk://#diff-2aec2b98475566b74f8a8bb2d2a3120d6a08ac8e53ac3941b38519adfa85c348L44-R50) [[2]](diffhunk://#diff-2aec2b98475566b74f8a8bb2d2a3120d6a08ac8e53ac3941b38519adfa85c348L71-R77) [[3]](diffhunk://#diff-976ab809bfa5ec44f8f4723a5edaa5e4d78be83000884d26ea5f1e69344c2dceL67-R67) [[4]](diffhunk://#diff-976ab809bfa5ec44f8f4723a5edaa5e4d78be83000884d26ea5f1e69344c2dceL94-R94)

### Code Hygiene

* Added `#[allow(dead_code)]` attributes to several functions and traits in `uka_shiori/src/dll/adapter.rs` and `uka_shiori/src/dll/caller.rs` to suppress warnings about unused code. [[1]](diffhunk://#diff-6b51c86378edefa2918c14931ac5878efcf8abb64b5ab934feae44e8449148bcR262) [[2]](diffhunk://#diff-d60117cb9c00b7d6e54f078b1b62616ef19ff45816889e3ebf4ac741d923a5c7R31) [[3]](diffhunk://#diff-d60117cb9c00b7d6e54f078b1b62616ef19ff45816889e3ebf4ac741d923a5c7R81) [[4]](diffhunk://#diff-d60117cb9c00b7d6e54f078b1b62616ef19ff45816889e3ebf4ac741d923a5c7R110)

### Build Configuration

* Set the workspace resolver to version 2 in `Cargo.toml` for improved dependency resolution.